### PR TITLE
Add es6 compilation + tests (fixes #18)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "it": false,
     "module": false,
     "require": false,
+    "sinon": false,
   },
   "rules": {
     "block-scoped-var": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+dist/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,6 @@ module.exports = function(grunt) {
 
   grunt.initConfig(configs);
 
-  grunt.registerTask('test', ['mochaTest', 'eslint']);
+  grunt.registerTask('test', ['webpack:test', 'mochaTest', 'eslint']);
 
 };

--- a/package.json
+++ b/package.json
@@ -18,13 +18,24 @@
   "homepage": "https://github.com/mozilla/addons-validator#readme",
   "private": true,
   "devDependencies": {
+    "babel-core": "5.8.25",
     "babel-eslint": "4.1.2",
-    "chai": "3.2.0",
+    "babel-loader": "5.3.2",
+    "chai": "3.3.0",
     "grunt": "0.4.5",
     "grunt-eslint": "17.1.0",
     "grunt-mocha-test": "0.12.7",
+    "grunt-webpack": "1.0.11",
+    "json-loader": "0.5.3",
     "load-grunt-configs": "0.4.3",
     "load-grunt-tasks": "3.2.0",
-    "mocha": "2.3.2"
+    "mocha": "2.3.2",
+    "mocha-loader": "0.7.1",
+    "sinon": "1.17.0",
+    "webpack": "1.12.2",
+    "webpack-dev-server": "1.11.0"
+  },
+  "dependencies": {
+    "source-map-support": "0.3.2"
   }
 }

--- a/src/foo.js
+++ b/src/foo.js
@@ -1,0 +1,5 @@
+
+
+export function foo() {
+  return 'hello';
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,13 @@
+import { foo } from 'foo';
+import { join } from 'path';
+
+
+export class Foo {
+
+  constructor(foo_=foo, join_=join) {
+    this.bar = 'test';
+    foo_();
+    join_('foo', 'bar');
+  }
+
+}

--- a/tasks/mochaTest.js
+++ b/tasks/mochaTest.js
@@ -2,10 +2,13 @@ module.exports = {
   options: {
     require: [
       function() {
-        assert = require('chai').assert;  // eslint-disable-line
+        /*eslint-disable */
+        assert = require('chai').assert;
+        sinon = require('sinon') //
+        /*eslint-enable */
       },
     ],
     reporter: 'spec',
   },
-  all: ['tests/*.js'],
+  all: ['dist/tests.js'],
 };

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -1,0 +1,17 @@
+var webpackConfig = require('../webpack.config.js');
+var path = require('path');
+
+module.exports = {
+  options: webpackConfig,
+  build: {
+    // Use the default webpack options.
+  },
+  test: {
+    entry: './tests/runner.js',
+    output: {
+      path: path.join(__dirname, '../dist'),
+      filename: 'tests.js',
+    },
+
+  },
+};

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,0 +1,7 @@
+// Webpack tests entry point. Bundles all the test files
+// into a single file.
+
+import 'babel-core/polyfill';
+
+var context = require.context('.', true, /.*?test\..*?.js$/);
+context.keys().forEach(context);

--- a/tests/test.basic.js
+++ b/tests/test.basic.js
@@ -5,4 +5,3 @@ describe('Basic test', function(){
   });
 
 });
-

--- a/tests/test.es6.js
+++ b/tests/test.es6.js
@@ -1,0 +1,13 @@
+import { Foo } from 'main';
+
+describe('Mocha es6 test', function() {
+
+  it('should run a class with no probs', function() {
+    var fooStub = sinon.stub();
+    var joinStub = sinon.stub();
+    var _unusedFoo = new Foo(fooStub, joinStub); //eslint-disable-line
+    assert.ok(fooStub.called);
+    assert.ok(joinStub.calledWithExactly('foo', 'bar'));
+  });
+
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,50 @@
+var webpack = require('webpack');
+var path = require('path');
+var fs = require('fs');
+
+var nodeModules = {};
+
+// This is to filter out node_modules as we don't want them
+// to be made part of any bundles.
+fs.readdirSync('node_modules')
+  .filter(function(x) {
+    return ['.bin'].indexOf(x) === -1;
+  })
+  .forEach(function(mod) {
+    nodeModules[mod] = 'commonjs ' + mod;
+  });
+
+
+module.exports = {
+  entry: './src/main.js',
+  target: 'node',
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: 'addon-validator.js',
+  },
+  module: {
+    loaders: [
+      {
+        exclude: /(node_modules|bower_components)/,
+        test: /\.js$/,
+        // es7.objectRestSpread to enable ES7 rest spread operators
+        // eg: let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };
+        loaders: ['babel?optional[]=es7.objectRestSpread&' +
+                  'optional[]=es7.classProperties&stage=2'],
+      },
+    ],
+  },
+  externals: nodeModules,
+  plugins: [
+    new webpack.BannerPlugin('require("source-map-support").install();',
+                             { raw: true, entryOnly: false }),
+  ],
+  resolve: {
+    extensions: ['', '.js', '.json'],
+    modulesDirectories: [
+      'node_modules',
+      'src/',
+    ],
+  },
+  devtool: 'sourcemap',
+};


### PR DESCRIPTION
Note the code and the tests are just some dummy content to prove this is working. It can all be removed as soon as we have some real code to test.

This setup allows for a bundle made from the src/main.js entry point + one for tests.

Test runs build the bundle and test that. The sourcemaps should mean we get meaningful pointers to the code. I've followed the way the karma setup works as much as possible. 

Running a single test can be a bit of a pain due to the bundling but generally this should run very quickly.

If that proves to be a problem then we can look at this in due course. Also it should be possible to have this setup to rebuild/retest on changes if we want. That can also come later.

Other notes: Tests get `sinon` and `chai.assert` for free you don't need to import them. If we have any useful helpers we can consider doing similar for those too. Just saves on repetition.
