### PR TITLE
Add message object fixes (#28)

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -1,0 +1,4 @@
+export const DEFLATE_COMPRESSION = 8;
+export const NO_COMPRESSION = 0;
+export const MESSAGE_TYPES = ['error', 'notice', 'warning'];
+export const SIGNING_SEVERITIES = ['trivial', 'low', 'medium', 'high'];

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,0 @@
-export const DEFLATE_COMPRESSION = 8;
-export const NO_COMPRESSION = 0;

--- a/src/message.js
+++ b/src/message.js
@@ -1,0 +1,56 @@
+import { MESSAGE_TYPES, SIGNING_SEVERITIES } from 'const';
+
+
+// These are the optional fields we expect to pull out of
+// the opts object passed to the Message constructor.
+export var fields = [
+  'id',
+  'message',
+  'description',
+  'file',
+  'line',
+  'column',
+  'for_appversions',
+  'compatibility_type',
+  'signing_help',
+  'signing_severity',
+];
+
+
+export default class Message {
+
+  constructor(type, opts={}) {
+    this.type = type;
+    for (let field of fields) {
+      this[field] = opts[field];
+    }
+    this.editorsOnly = opts.editorsOnly || false;
+  }
+
+  get type() {
+    return this._type;
+  }
+
+  set type(type) {
+    if (MESSAGE_TYPES.indexOf(type) === -1) {
+      throw new Error(
+        `Message type "${type}" is not one of ${MESSAGE_TYPES.join(', ')}`);
+    }
+    this._type = type;
+  }
+
+  get signing_severity() {
+    return this._signing_severity;
+  }
+
+  set signing_severity(severity) {
+    if (typeof severity !== 'undefined') {
+      if (SIGNING_SEVERITIES.indexOf(severity) === -1) {
+        throw new Error(
+          `Severity "${severity}" is not one of ` +
+          `${SIGNING_SEVERITIES.join(', ')}`);
+      }
+    }
+    this._signing_severity = severity;
+  }
+}

--- a/tests/test.message.js
+++ b/tests/test.message.js
@@ -1,0 +1,48 @@
+import { default as Message, fields } from 'message';
+
+/*eslint no-unused-vars:0*/
+
+describe('Message', function() {
+
+  it('should throw on missing type', () => {
+    assert.throws(() => {
+      var MyMessage = new Message();
+    }, Error, /Message type "undefined" is not/);
+  });
+
+  it('should throw on invalid type', () => {
+    assert.throws(() => {
+      var MyMessage = new Message('awooga');
+    }, Error, /Message type "awooga" is not/);
+  });
+
+  it('should throw on incorrect signing_severity', () => {
+    assert.throws(() => {
+      var MyMessage = new Message('error',
+        {signing_severity: 'whatever'});
+    }, Error, /Severity "whatever" is not/);
+  });
+
+  it('should define all expected fields', () => {
+    var fakeOpts = {};
+    for (let field of fields) {
+      fakeOpts[field] = field;
+    }
+    fakeOpts.signing_severity = 'medium';
+    var MyMessage = new Message('error', fakeOpts);
+    for (let field of fields) {
+      if (field === 'signing_severity') {
+        assert.equal(MyMessage.signing_severity, 'medium');
+      } else {
+        assert.equal(MyMessage[field], field);
+      }
+    }
+  });
+
+  it ("shouldn't define random opts", () => {
+    var MyMessage = new Message('error', {random: 'foo'});
+    assert.notEqual(MyMessage.random, 'foo');
+  });
+
+});
+

--- a/tests/test.xpi.js
+++ b/tests/test.xpi.js
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 
 import Xpi from 'xpi';
-import { DEFLATE_COMPRESSION, NO_COMPRESSION } from 'constants';
+import { DEFLATE_COMPRESSION, NO_COMPRESSION } from 'const';
 
 const defaultData = {
   compressionMethod: DEFLATE_COMPRESSION,


### PR DESCRIPTION
Had to move the constants module to const as this clashed with a built-in module.

This adds a basic object for the validation output. We'll need to expand on this in due course but it will be used by the collector module to collect errors, warnings and notices as we go.