### PR TITLE
Add template tag for concatenating multiline strings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,29 @@
+/*
+ * Template tag for removing whitespace and new lines
+ * in order to be able to use multiline template strings
+ * as a single string.
+ *
+ * Usage: singleLineString`foo bar baz
+ *                    whatever`;
+ *
+ * Will output: 'foo bar baz whatever'
+ *
+ */
+
+export function singleLineString(strings, ...vars) {
+  // Interweave the strings with the
+  // substitution vars first.
+  let output = '';
+  for (let i = 0; i < vars.length; i++) {
+    output += strings[i] + vars[i];
+  }
+  output += strings[vars.length];
+
+  // Split on newlines.
+  let lines = output.split(/(?:\r\n|\n|\r)/);
+
+  // Rip out the leading whitespace.
+  return lines.map((line) => {
+    return line.replace(/^\s+/gm, '');
+  }).join(' ').trim();
+}

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -1,0 +1,37 @@
+import * as utils from 'utils';
+
+
+describe('utils.singleLineString()', function() {
+
+  it('reduce a multiline template string into one string', () => {
+    var output = utils.singleLineString`foo
+              bar
+        baz`;
+    assert.equal(output, 'foo bar baz');
+  });
+
+  it('should still do subs', () => {
+    var foo = 1;
+    var bar = 2;
+    var baz = 3;
+    var output = utils.singleLineString`one ${foo}
+              two ${bar}
+        three ${baz}`;
+    assert.equal(output, 'one 1 two 2 three 3');
+  });
+
+  it('should still work with tabs', () => {
+    var me = 'me';
+    var raggedy = 'raggedy';
+    var you = 'you';
+    // jscs:disable
+    var output = utils.singleLineString`So here is us, on the
+          ${raggedy} edge. Don't push ${me},
+              			and I won't push ${you}.`;
+    // jscs:enable
+    assert.equal(output,
+      'So here is us, on the raggedy edge. ' +
+      "Don't push me, and I won't push you.");
+  });
+
+});


### PR DESCRIPTION
Allows for this kind of thing:

![js_bin_-_collaborative_javascript_debugging](https://cloud.githubusercontent.com/assets/1514/10232683/117d8ce0-6882-11e5-9874-c791e2a67617.png)
