### PR TITLE
Restore newlines in CLI output

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -52,7 +52,7 @@ export default argv
     describe: singleLineString`JSON string to override the package's
       targetapp_maxVersion for validation. The JSON object should be
       a dict of versions keyed by application GUID. For example,
-      setting a package's max Firefox version to 5.*:
+      setting a package's max Firefox version to 5.*:<newline>
       {"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}": "5.*"}`,
     type: 'string',
   })
@@ -60,7 +60,7 @@ export default argv
     describe: singleLineString`JSON string to override the package's
       targetapp_minVersion for validation. The JSON object should
       be a dict of versions keyed by application GUID. For example,
-      setting a package's min Firefox version to 5.*:
+      setting a package's min Firefox version to 5.*:<newline>
       {"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}": "5.*"}`,
     type: 'string',
   })
@@ -68,7 +68,7 @@ export default argv
     describe: singleLineString`JSON string to run validation tests for
       compatibility with a specific app/version. The JSON object should
       be a dict of version lists keyed by application GUID. For example,
-      running Firefox 6.* compatibility tests:
+      running Firefox 6.* compatibility tests:<newline>
       {"{ec8030f7-c20a-464f-9b0e-13a3a9e97384}": ["6.*"]`,
     type: 'string',
   })

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,8 @@
  *
  * Will output: 'foo bar baz whatever'
  *
+ * Sometimes you do want newlines, you can manually add one with `<newline>`.
+ *
  */
 
 export function singleLineString(strings, ...vars) {
@@ -25,5 +27,5 @@ export function singleLineString(strings, ...vars) {
   // Rip out the leading whitespace.
   return lines.map((line) => {
     return line.replace(/^\s+/gm, '');
-  }).join(' ').trim();
+  }).join(' ').trim().replace('<newline>', '\n');
 }


### PR DESCRIPTION
Just realised that when we added the `singleLineString` template tag in #41, we removed intentional newlines before JSON strings (eg: https://github.com/mozilla/addons-validator/blob/master/src/cli.js#L63).

This restores them in a way I hope isn't offensive. I still think it's nicer (and more explicit/obvious) than just allowing string concat on that line.

r?