### PR TITLE
Handle duplicate files in xpi (fixes #38, fixes #37)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -26,6 +26,11 @@ export default argv
     default: 'text',
     choices: ['json', 'text'],
   })
+  .option('pretty', {
+    describe: 'Prettify JSON output',
+    type: 'boolean',
+    default: false,
+  })
   .option('stack', {
     describe: 'Show stacktraces when errors are thrown',
     type: 'boolean',

--- a/src/collector.js
+++ b/src/collector.js
@@ -1,4 +1,5 @@
 import { default as Message } from 'message';
+import * as constants from 'const';
 
 // "I have a display case ready and waiting for our newest acquisitions!"
 // --Taneleer Tivan
@@ -7,15 +8,17 @@ import { default as Message } from 'message';
 export default class Collector {
 
   constructor() {
-    this.errors = [];
-    this.notices = [];
-    this.warnings = [];
+    for (let type of constants.MESSAGE_TYPES) {
+      this[`${type}s`] = [];
+    }
   }
 
   get length() {
-    return this.errors.length +
-      this.notices.length +
-      this.warnings.length;
+    var len = 0;
+    for (let type of constants.MESSAGE_TYPES) {
+      len += this[`${type}s`].length;
+    }
+    return len;
   }
 
   _addMessage(type, opts, _Message=Message) {
@@ -30,14 +33,15 @@ export default class Collector {
   }
 
   addError(opts) {
-    this._addMessage('error', opts);
+    this._addMessage(constants.VALIDATION_ERROR, opts);
   }
 
   addNotice(opts) {
-    this._addMessage('notice', opts);
+    this._addMessage(constants.VALIDATION_NOTICE, opts);
   }
 
   addWarning(opts) {
-    this._addMessage('warning', opts);
+    this._addMessage(constants.VALIDATION_WARNING, opts);
   }
+
 }

--- a/src/const.js
+++ b/src/const.js
@@ -1,4 +1,12 @@
 export const DEFLATE_COMPRESSION = 8;
 export const NO_COMPRESSION = 0;
-export const MESSAGE_TYPES = ['error', 'notice', 'warning'];
-export const SIGNING_SEVERITIES = ['trivial', 'low', 'medium', 'high'];
+
+export const VALIDATION_ERROR = 'error';
+export const VALIDATION_NOTICE = 'notice';
+export const VALIDATION_WARNING = 'warning';
+
+export const MESSAGE_TYPES = [
+  VALIDATION_ERROR,
+  VALIDATION_NOTICE,
+  VALIDATION_WARNING,
+];

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -1,0 +1,15 @@
+export class ExtensibleError extends Error {
+  constructor(message) {
+    super();
+    this.message = message;
+    this.name = this.constructor.name;
+    if (Error.hasOwnProperty('captureStackTrace')) {
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = (new Error()).stack;
+    }
+  }
+}
+
+export class DuplicateZipEntryError extends ExtensibleError {}
+

--- a/src/message.js
+++ b/src/message.js
@@ -1,30 +1,41 @@
-import { MESSAGE_TYPES, SIGNING_SEVERITIES } from 'const';
+import { MESSAGE_TYPES } from 'const';
+import { singleLineString } from 'utils';
 
 
-// These are the optional fields we expect to pull out of
-// the opts object passed to the Message constructor.
-export var fields = [
-  'id',
+// These are the props we expect to pull out of
+// the data object passed to the Message constructor.
+export var props = [
+  'code',
   'message',
   'description',
+  'column',
   'file',
   'line',
-  'column',
-  'for_appversions',
-  'compatibility_type',
-  'signing_help',
-  'signing_severity',
 ];
 
+export var requiredProps = [
+  'code',
+  'message',
+  'description',
+];
 
 export default class Message {
 
-  constructor(type, opts={}) {
+  constructor(type, data={}) {
     this.type = type;
-    for (let field of fields) {
-      this[field] = opts[field];
+    for (let prop of props) {
+      this[prop] = data[prop];
     }
-    this.editorsOnly = opts.editorsOnly || false;
+    var missingProps = [];
+    for (let prop of requiredProps) {
+      if (typeof this[prop] === 'undefined') {
+        missingProps.push(prop);
+      }
+    }
+    if (missingProps.length) {
+      throw new Error(singleLineString`Message data object is missing the
+        following props: ${missingProps.join(', ')}`);
+    }
   }
 
   get type() {
@@ -33,24 +44,10 @@ export default class Message {
 
   set type(type) {
     if (MESSAGE_TYPES.indexOf(type) === -1) {
-      throw new Error(
-        `Message type "${type}" is not one of ${MESSAGE_TYPES.join(', ')}`);
+      throw new Error(singleLineString`Message type "${type}"
+        is not one of ${MESSAGE_TYPES.join(', ')}`);
     }
     this._type = type;
   }
 
-  get signing_severity() {
-    return this._signing_severity;
-  }
-
-  set signing_severity(severity) {
-    if (typeof severity !== 'undefined') {
-      if (SIGNING_SEVERITIES.indexOf(severity) === -1) {
-        throw new Error(
-          `Severity "${severity}" is not one of ` +
-          `${SIGNING_SEVERITIES.join(', ')}`);
-      }
-    }
-    this._signing_severity = severity;
-  }
 }

--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -1,0 +1,4 @@
+// Here we can re-export all our message so one can just do
+// import * as messages from 'messages';
+
+export * from './layout';

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -1,0 +1,10 @@
+import { gettext, singleLineString } from 'utils';
+
+
+export const DUPLICATE_XPI_ENTRY = {
+  code: 'DUPLICATE_XPI_ENTRY',
+  message: gettext('Package contains duplicate entries'),
+  description: gettext(singleLineString`The package contains multiple entries
+    with the same name. This practice has been banned. Try unzipping
+    and re-zipping your add-on package and try again.`),
+};

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -1,10 +1,10 @@
-import { gettext, singleLineString } from 'utils';
+import { gettext as _, singleLineString } from 'utils';
 
 
 export const DUPLICATE_XPI_ENTRY = {
   code: 'DUPLICATE_XPI_ENTRY',
-  message: gettext('Package contains duplicate entries'),
-  description: gettext(singleLineString`The package contains multiple entries
+  message: _('Package contains duplicate entries'),
+  description: _(singleLineString`The package contains multiple entries
     with the same name. This practice has been banned. Try unzipping
     and re-zipping your add-on package and try again.`),
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,3 +27,12 @@ export function singleLineString(strings, ...vars) {
     return line.replace(/^\s+/gm, '');
   }).join(' ').trim();
 }
+
+/*
+ * Gettext utils. No-op until we have proper
+ * a proper l10n solution.
+ *
+ */
+export function gettext(str) {
+  return str;
+}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,5 @@
+export const fakeMessageData = {
+  code: 'WHATEVER_CODE',
+  description: 'description',
+  message: 'message',
+};

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -29,6 +29,11 @@ describe('Basic CLI tests', function() {
     assert.equal(args.stack, false);
   });
 
+  it('should default pretty to false', () => {
+    var args = cli.parse(['foo/bar.xpi']);
+    assert.equal(args.pretty, false);
+  });
+
   it('should default selfhosted to false', () => {
     var args = cli.parse(['foo/bar.xpi']);
     assert.equal(args.selfhosted, false);

--- a/tests/test.collector.js
+++ b/tests/test.collector.js
@@ -1,5 +1,5 @@
 import { default as Collector } from 'collector';
-
+import { fakeMessageData } from './helpers';
 
 describe('Collector', function() {
 
@@ -21,7 +21,7 @@ describe('Collector', function() {
     assert.throws(() => {
       var FakeMessage = sinon.stub();
       var collection = new Collector();
-      collection._addMessage('whatevar', {}, FakeMessage);
+      collection._addMessage('whatevar', fakeMessageData, FakeMessage);
     }, Error, /Message type "whatevar" not currently collected/);
   });
 
@@ -33,17 +33,17 @@ describe('Collector', function() {
   it('length should reflect number of messages', () => {
     var collection = new Collector();
     assert.equal(collection.length, 0);
-    collection.addError({});
+    collection.addError(fakeMessageData);
     assert.equal(collection.length, 1);
-    collection.addNotice({});
+    collection.addNotice(fakeMessageData);
     assert.equal(collection.length, 2);
-    collection.addWarning({});
+    collection.addWarning(fakeMessageData);
     assert.equal(collection.length, 3);
   });
 
   it('should create an error message', () => {
     var collection = new Collector();
-    collection.addError({});
+    collection.addError(fakeMessageData);
     assert.equal(collection.errors[0].type, 'error');
     assert.equal(collection.notices.length, 0);
     assert.equal(collection.warnings.length, 0);
@@ -51,7 +51,7 @@ describe('Collector', function() {
 
   it('should create a notice message', () => {
     var collection = new Collector();
-    collection.addNotice({});
+    collection.addNotice(fakeMessageData);
     assert.equal(collection.notices[0].type, 'notice');
     assert.equal(collection.errors.length, 0);
     assert.equal(collection.warnings.length, 0);
@@ -59,7 +59,7 @@ describe('Collector', function() {
 
   it('should create a warning message', () => {
     var collection = new Collector();
-    collection.addWarning({});
+    collection.addWarning(fakeMessageData);
     assert.equal(collection.warnings[0].type, 'warning');
     assert.equal(collection.errors.length, 0);
     assert.equal(collection.notices.length, 0);

--- a/tests/test.exceptions.js
+++ b/tests/test.exceptions.js
@@ -1,0 +1,22 @@
+import * as exceptions from 'exceptions';
+
+
+describe('DuplicateZipEntry()', function() {
+
+  it('should have correct message', () => {
+    assert.throws(() => {
+      throw new exceptions.DuplicateZipEntryError('whatever');
+    }, exceptions.DuplicateZipEntry, /whatever/);
+  });
+
+  it('should have correct message', () => {
+    try {
+      throw new exceptions.DuplicateZipEntryError('whatever');
+    } catch (e) {
+      assert.instanceOf(e, exceptions.DuplicateZipEntryError);
+      assert.equal(e.message, 'whatever');
+      assert.equal(e.name, 'DuplicateZipEntryError');
+    }
+  });
+
+});

--- a/tests/test.message.js
+++ b/tests/test.message.js
@@ -1,4 +1,5 @@
-import { default as Message, fields } from 'message';
+import { default as Message, props } from 'message';
+import { fakeMessageData } from './helpers';
 
 /*eslint no-unused-vars:0*/
 
@@ -16,32 +17,28 @@ describe('Message', function() {
     }, Error, /Message type "awooga" is not/);
   });
 
-  it('should throw on incorrect signing_severity', () => {
-    assert.throws(() => {
-      var MyMessage = new Message('error',
-        {signing_severity: 'whatever'});
-    }, Error, /Severity "whatever" is not/);
-  });
-
-  it('should define all expected fields', () => {
-    var fakeOpts = {};
-    for (let field of fields) {
-      fakeOpts[field] = field;
+  it('should define all expected props', () => {
+    var fakeData = {};
+    for (let prop of props) {
+      fakeData[prop] = prop;
     }
-    fakeOpts.signing_severity = 'medium';
-    var MyMessage = new Message('error', fakeOpts);
-    for (let field of fields) {
-      if (field === 'signing_severity') {
-        assert.equal(MyMessage.signing_severity, 'medium');
-      } else {
-        assert.equal(MyMessage[field], field);
-      }
+    var MyMessage = new Message('error', fakeData);
+    for (let prop of props) {
+      assert.equal(MyMessage[prop], prop);
     }
   });
 
   it ("shouldn't define random opts", () => {
-    var MyMessage = new Message('error', {random: 'foo'});
+    var MyMessage = new Message('error',
+      Object.assign({}, fakeMessageData, {random: 'foo'}));
     assert.notEqual(MyMessage.random, 'foo');
+  });
+
+  it('should throw on missing required prop', () => {
+    assert.throws(() => {
+      var MyMessage = new Message('error',
+        Object.assign({}, {description: 'foo'}));
+    }, Error, /Message data object is missing the following props/);
   });
 
 });

--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -1,5 +1,8 @@
 import Validator from 'validator';
 
+import * as messages from 'messages';
+import { fakeMessageData } from './helpers';
+import { DuplicateZipEntryError } from 'exceptions';
 
 
 describe('Validator', function() {
@@ -58,6 +61,50 @@ describe('Validator', function() {
         assert.instanceOf(err, Error);
         assert.include(err.message, 'Path "bar" is not a file');
         assert.equal(isFileSpy.callCount, 1);
+      });
+  });
+
+  it('should provide output via output prop', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    addonValidator.collector.addError(fakeMessageData);
+    var output = addonValidator.output;
+    assert.equal(output.count, 1);
+    assert.equal(output.summary.errors, 1);
+    assert.equal(output.summary.notices, 0);
+    assert.equal(output.summary.warnings, 0);
+  });
+
+  it('should provide JSON via toJSON()', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    addonValidator.collector.addError(fakeMessageData);
+    var json = addonValidator.toJSON();
+    var parsedJSON = JSON.parse(json);
+    assert.equal(parsedJSON.count, 1);
+    assert.equal(parsedJSON.summary.errors, 1);
+    assert.equal(parsedJSON.summary.notices, 0);
+    assert.equal(parsedJSON.summary.warnings, 0);
+  });
+
+  it('should call addError when Xpi rejects with dupe entry', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    addonValidator.checkFileExists = () => Promise.resolve();
+    addonValidator.collector.addError = sinon.stub();
+    addonValidator.print = sinon.stub();
+    class FakeXpi {
+      getMetaData() {
+        return Promise.reject(
+          new DuplicateZipEntryError('Darnit the zip has dupes!'));
+      }
+    }
+    return addonValidator.scan(FakeXpi)
+      .then(() => {
+        assert.fail(null, null, 'Unexpected success');
+      })
+      .catch(() => {
+        assert.ok(
+          addonValidator.collector.addError.calledWith(
+            messages.DUPLICATE_XPI_ENTRY));
+        assert.ok(addonValidator.print.called);
       });
   });
 


### PR DESCRIPTION
Ended up covering a quite a lot of ground here - as yaks reared their ugly heads I shaved them :).

* collector messageType lists are now produced through iterating over constants
* messageTypes are now constants
* required message types are handled (see #38)
* Xpi throws a custom exception DuplicateZipEntryError when an entry already seen comes up.
* Validator now has a output property and a toJSON method + a print() method.
* Fixed a race condition in the Xpi class. We now listen to `close` rather than `end` because the latter resulted in resolution of the promise before the last entry was processed (and rejected).