### PR TITLE
Fix issue with close not called when openReadStream is invoked

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "spread": true,
   },
   "globals": {
+    "afterEach": false,
     "assert": false,
     "beforeEach": false,
     "describe": false,

--- a/src/xpi.js
+++ b/src/xpi.js
@@ -21,24 +21,6 @@ export default class Xpi {
     this.entries = [];
   }
 
-  handleEntry(entry, zipfile, reject) {
-    if (/\/$/.test(entry.fileName)) {
-      return;
-    }
-    // Collect metadata for files.
-    zipfile.openReadStream(entry, (err) => {
-      if (err) {
-        return reject(err);
-      }
-      if (this.entries.indexOf(entry.fileName) > -1) {
-        return reject(new DuplicateZipEntryError(
-          `Entry "${entry.fileName}" has already been seen`));
-      }
-      this.entries.push(entry.fileName);
-      this.metadata[entry.fileName] = entry;
-    });
-  }
-
   open() {
     return new Promise((resolve, reject) => {
       this.zipLib.open(this.filename, (err, zipfile) => {
@@ -48,6 +30,18 @@ export default class Xpi {
         resolve(zipfile);
       });
     });
+  }
+
+  handleEntry(entry, reject) {
+    if (/\/$/.test(entry.fileName)) {
+      return;
+    }
+    if (this.entries.indexOf(entry.fileName) > -1) {
+      reject(new DuplicateZipEntryError(
+        `Entry "${entry.fileName}" has already been seen`));
+    }
+    this.entries.push(entry.fileName);
+    this.metadata[entry.fileName] = entry;
   }
 
   getMetaData(_onEventsSubscribed) {
@@ -60,9 +54,11 @@ export default class Xpi {
 
       return this.open()
         .then((zipfile) => {
+
           zipfile.on('entry', (entry) => {
-            this.handleEntry(entry, zipfile, reject);
+            this.handleEntry(entry, reject);
           });
+
           // When the last entry has been processed
           // and the fd is closed resolve the promise.
           // Note: we cannot use 'end' here as 'end' is fired
@@ -71,6 +67,7 @@ export default class Xpi {
           zipfile.on('close', () => {
             resolve(this.metadata);
           });
+
           if (_onEventsSubscribed) {
             // Run optional callback when we know the event handlers
             // have been inited. Useful for testing.
@@ -79,7 +76,7 @@ export default class Xpi {
             }
           }
         })
-        .catch((err) => reject(err));
+        .catch(reject);
     });
   }
 


### PR DESCRIPTION
The close event wasn't being fired when getting the metadata for zips. I think it might be because when you call openReadStream you need to inhale the entire stream. If you call openReadStream and don't consume the stream it results in the close event not firing. Anyhoo, looking at our code it made me realise we don't really need to use `openReadStream` just to get the metadata that we already have.

Fixing the tests now that handleEntry is sync was a bit of a pain, but I found a better way to get the callback pass to `zipfile.on('entry', cb)`. This then means that the handleEntry code is called properly in the way it was registered rather than directly, which makes for a more consistent approach for all cases where we are adding metadata during testing.