### PR TITLE
Handle invalid JS; add an error when encountered

### DIFF
--- a/src/javascript.js
+++ b/src/javascript.js
@@ -31,8 +31,9 @@ export default class JavaScriptScanner {
       for (let message of report.results[0].messages) {
         // Fatal error messages (like SyntaxErrors) are a bit different, we
         // need to handle them specially.
-        if (message.fatal) {
+        if (message.fatal === true) {
           message.ruleId = messages.JS_SYNTAX_ERROR.code;
+          // message.severity = VALIDATION_ERROR;
         }
 
         validatorMessages.push({
@@ -46,6 +47,8 @@ export default class JavaScriptScanner {
           type: ESLINT_TYPES[message.severity],
         });
       }
+
+      console.log(validatorMessages);
 
       resolve(validatorMessages);
     });

--- a/src/javascript.js
+++ b/src/javascript.js
@@ -29,6 +29,12 @@ export default class JavaScriptScanner {
       var report = eslint.executeOnText(this.code, this.filename);
 
       for (let message of report.results[0].messages) {
+        // Fatal error messages (like SyntaxErrors) are a bit different, we
+        // need to handle them specially.
+        if (message.fatal) {
+          message.ruleId = messages.JS_SYNTAX_ERROR.code;
+        }
+
         validatorMessages.push({
           code: message.ruleId.toUpperCase(),
           column: message.column,

--- a/src/javascript.js
+++ b/src/javascript.js
@@ -33,7 +33,6 @@ export default class JavaScriptScanner {
         // need to handle them specially.
         if (message.fatal === true) {
           message.ruleId = messages.JS_SYNTAX_ERROR.code;
-          // message.severity = VALIDATION_ERROR;
         }
 
         validatorMessages.push({
@@ -47,8 +46,6 @@ export default class JavaScriptScanner {
           type: ESLINT_TYPES[message.severity],
         });
       }
-
-      console.log(validatorMessages);
 
       resolve(validatorMessages);
     });

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -1,14 +1,21 @@
-import { gettext as _ } from 'utils';
+import { gettext as _, singleLineString } from 'utils';
 
+
+export const JS_SYNTAX_ERROR = {
+  code: 'JS_SYNTAX_ERROR',
+  message: _('JavaScript syntax error'),
+  description: _(singleLineString`There is a JavaScript syntax error in your
+    code; validation cannot continue on this file.`),
+};
 
 export const MOZINDEXEDDB = {
   code: 'MOZINDEXEDDB',
-  message: _('mozIndexedDB has been removed; use indexedDB instead.'),
+  message: _('mozIndexedDB has been removed; use indexedDB instead'),
   description: _('mozIndexedDB has been removed; use indexedDB instead.'),
 };
 
 export const MOZINDEXEDDB_PROPERTY = {
   code: 'MOZINDEXEDDB_PROPERTY',
-  message: _('mozIndexedDB used as an object key/property.'),
+  message: _('mozIndexedDB used as an object key/property'),
   description: _('mozIndexedDB has been removed; use indexedDB instead.'),
 };

--- a/tests/test.javascript.js
+++ b/tests/test.javascript.js
@@ -73,7 +73,7 @@ describe('JS Code Checker', function() {
     return jsScanner.scan()
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
-        assert.equal(validationMessages[0].id, 'mozIndexedDB_possible');
+        assert.equal(validationMessages[0].id, 'OBFUSCATION');
         assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
       });
   });
@@ -88,7 +88,7 @@ describe('JS Code Checker', function() {
     return jsScanner.scan()
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
-        assert.equal(validationMessages[0].id, 'mozIndexedDB_possible');
+        assert.equal(validationMessages[0].id, 'OBFUSCATION');
         assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
       });
   });
@@ -104,7 +104,7 @@ describe('JS Code Checker', function() {
     return jsScanner.scan()
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
-        assert.equal(validationMessages[0].id, 'mozIndexedDB_possible');
+        assert.equal(validationMessages[0].id, 'OBFUSCATION');
         assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
       });
   });
@@ -121,8 +121,30 @@ describe('JS Code Checker', function() {
     return jsScanner.scan()
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
-        assert.equal(validationMessages[0].id, 'mozIndexedDB_possible');
+        assert.equal(validationMessages[0].id, 'OBFUSCATION');
         assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+      });
+  });
+
+  it('should create an error message when encountering a syntax error', () => {
+    var code = 'var m = "d;';
+    var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+    return jsScanner.scan()
+      .then((validationMessages) => {
+        assert.equal(validationMessages[0].id, messages.JS_SYNTAX_ERROR.code);
+        assert.equal(validationMessages[0].severity, VALIDATION_ERROR);
+
+        // Test another error for good measure.
+        code = 'var aVarThatDoesnt != exist;';
+        jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+        return jsScanner.scan()
+          .then((moreValidationMessages) => {
+            assert.equal(moreValidationMessages[0].id,
+                         messages.JS_SYNTAX_ERROR.code);
+            assert.equal(moreValidationMessages[0].severity, VALIDATION_ERROR);
+          });
       });
   });
 

--- a/tests/test.javascript.js
+++ b/tests/test.javascript.js
@@ -56,7 +56,7 @@ describe('JS Code Checker', function() {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].id,
                      messages.MOZINDEXEDDB_PROPERTY.code);
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -74,7 +74,7 @@ describe('JS Code Checker', function() {
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].id, 'OBFUSCATION');
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -89,7 +89,7 @@ describe('JS Code Checker', function() {
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].id, 'OBFUSCATION');
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -105,7 +105,7 @@ describe('JS Code Checker', function() {
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].id, 'OBFUSCATION');
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -122,7 +122,7 @@ describe('JS Code Checker', function() {
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].id, 'OBFUSCATION');
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -132,8 +132,8 @@ describe('JS Code Checker', function() {
 
     return jsScanner.scan()
       .then((validationMessages) => {
-        assert.equal(validationMessages[0].id, messages.JS_SYNTAX_ERROR.code);
-        assert.equal(validationMessages[0].severity, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].code, messages.JS_SYNTAX_ERROR.code);
+        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
 
         // Test another error for good measure.
         code = 'var aVarThatDoesnt != exist;';
@@ -141,9 +141,9 @@ describe('JS Code Checker', function() {
 
         return jsScanner.scan()
           .then((moreValidationMessages) => {
-            assert.equal(moreValidationMessages[0].id,
+            assert.equal(moreValidationMessages[0].code,
                          messages.JS_SYNTAX_ERROR.code);
-            assert.equal(moreValidationMessages[0].severity, VALIDATION_ERROR);
+            assert.equal(moreValidationMessages[0].type, VALIDATION_ERROR);
           });
       });
   });


### PR DESCRIPTION
Adds a test case for malformed JS and a bit of extra code in the
JS Scanner to make sure we handle SyntaxErrors, which are a bit
different from other errors created by ESLint.

Fixes #52.