### PR TITLE
Make scanning more generic

### DIFF
--- a/src/javascript.js
+++ b/src/javascript.js
@@ -33,11 +33,11 @@ export default class JavaScriptScanner {
           code: message.ruleId.toUpperCase(),
           column: message.column,
           description: messages[message.ruleId.toUpperCase()].description,
-          sourceCode: message.source,
           file: this.filename,
           line: message.line,
           message: messages[message.ruleId.toUpperCase()].message,
-          severity: ESLINT_TYPES[message.severity],
+          sourceCode: message.source,
+          type: ESLINT_TYPES[message.severity],
         });
       }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,6 @@ export function endsWith(string, suffix) {
  * Will output: 'foo bar baz whatever'
  *
  */
-
 export function singleLineString(strings, ...vars) {
   // Interweave the strings with the
   // substitution vars first.

--- a/src/xpi.js
+++ b/src/xpi.js
@@ -3,6 +3,7 @@ import yauzl from 'yauzl';
 import { DuplicateZipEntryError } from 'exceptions';
 import { endsWith } from 'utils';
 
+
 /*
  * Simple Promise wrapper for the Yauzl unzipping lib to unpack add-on .xpis.
  * Note: We're using the autoclose feature of yauzl as a result every operation
@@ -118,21 +119,23 @@ export default class Xpi {
     });
   }
 
-  getJSFiles() {
+  getFilesByExt(ext) {
     return new Promise((resolve, reject) => {
+
+      if (ext.indexOf('.') !== 0) {
+        throw new Error("File extension must start with '.'");
+      }
+
       return this.getMetaData()
         .then((metadata) => {
-          let jsFiles = [];
+          let files = [];
 
           for (let filename in metadata) {
-            // TODO: Check for JS files better than this (follow require path)
-            // of add-on?
-            if (endsWith(filename, '.js')) {
-              jsFiles.push(filename);
+            if (endsWith(filename, ext)) {
+              files.push(filename);
             }
           }
-
-          resolve(jsFiles);
+          resolve(files);
         })
         .catch(reject);
     });

--- a/tests/test.javascript.js
+++ b/tests/test.javascript.js
@@ -14,7 +14,7 @@ describe('JS Code Checker', function() {
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code, messages.MOZINDEXEDDB.code);
-        assert.equal(validationMessages[0].severity, VALIDATION_ERROR);
+        assert.equal(validationMessages[0].type, VALIDATION_ERROR);
       });
   });
 
@@ -30,7 +30,7 @@ describe('JS Code Checker', function() {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code,
                      messages.MOZINDEXEDDB_PROPERTY.code);
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 
@@ -43,7 +43,7 @@ describe('JS Code Checker', function() {
         assert.equal(validationMessages.length, 1);
         assert.equal(validationMessages[0].code,
                      messages.MOZINDEXEDDB_PROPERTY.code);
-        assert.equal(validationMessages[0].severity, VALIDATION_WARNING);
+        assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });
   });
 

--- a/tests/test.xpi.js
+++ b/tests/test.xpi.js
@@ -317,6 +317,15 @@ describe('Xpi.getFileAsStream()', function() {
         assert.include(err.message, 'getFileAsString openReadStream test');
       });
   });
+});
+
+describe('Xpi.getFileAsStream()', function() {
+
+  beforeEach(() => {
+    this.fakeZipLib = {
+      open: this.openStub,
+    };
+  });
 
   it('should return all JS files', () => {
     var myXpi = new Xpi('foo/bar', this.fakeZipLib);
@@ -327,7 +336,7 @@ describe('Xpi.getFileAsStream()', function() {
       'secondary.js': jsSecondaryFileEntry,
     };
 
-    return myXpi.getJSFiles()
+    return myXpi.getFilesByExt('.js')
       .then((jsFiles) => {
         assert.equal(jsFiles.length, 2);
         assert.equal(jsFiles[0], 'main.js');
@@ -338,4 +347,26 @@ describe('Xpi.getFileAsStream()', function() {
         }
       });
   });
+
+  it('should return all CSS files', () => {
+    var myXpi = new Xpi('foo/bar', this.fakeZipLib);
+    myXpi.metadata = {
+      'other.css': installRdfEntry,
+      'chrome.manifest': chromeManifestEntry,
+      'styles.css': jsMainFileEntry,
+      'secondary.js': jsSecondaryFileEntry,
+    };
+
+    return myXpi.getFilesByExt('.css')
+      .then((cssFiles) => {
+        assert.equal(cssFiles.length, 2);
+        assert.equal(cssFiles[0], 'other.css');
+        assert.equal(cssFiles[1], 'styles.css');
+
+        for (let i = 0; i < cssFiles.length; i++) {
+          assert.ok(endsWith(cssFiles[i], '.css'));
+        }
+      });
+  });
+
 });


### PR DESCRIPTION
* Removed addToCollector as this was more aligned to JS Scanning specifics.
* Made `scanFile()` / `scanFiles()` so that we can just re-use for CSS etc. The expectation is now that you provide a list of raw data objects that messages can be created from. A type key is used to create the right message.
* `getJSFiles()` is now `getFilesByExt('.js')`
* Fixed the following tests as they weren't doing what they looked like they we doing.
    * https://github.com/mozilla/addons-validator/blob/master/tests/test.validator.js#L120
    * https://github.com/mozilla/addons-validator/blob/master/tests/test.validator.js#L135
