### PR TITLE
Quick fix to silence output (fixes #69)

### DIFF
--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -103,6 +103,7 @@ describe('Validator', function() {
   // - install.rdf
   it('should send JSScanner messages to the collector', () => {
     var addonValidator = new Validator({_: ['tests/example.xpi']});
+    addonValidator.print = sinon.stub();
 
     assert.equal(addonValidator.collector.errors.length, 0);
 
@@ -115,6 +116,7 @@ describe('Validator', function() {
   // Test to make sure we can all JS files inside an add-on, not just one.
   it('should scan all JS files', () => {
     var addonValidator = new Validator({_: ['tests/example.xpi']});
+    addonValidator.print = sinon.stub();
 
     var getFileSpy = sinon.spy(addonValidator, 'scanFile');
 
@@ -127,6 +129,7 @@ describe('Validator', function() {
   it('should see an error if scanFiles() blows up', () => {
     var addonValidator = new Validator({_: ['foo']});
     addonValidator.checkFileExists = () => Promise.resolve();
+    addonValidator.handleError = sinon.stub();
     addonValidator.scanFiles = () => {
       return Promise.reject(new Error('scanFiles explosion'));
     };
@@ -149,6 +152,7 @@ describe('Validator', function() {
 
   it('should bubble up the error if scanFile() blows up', () => {
     var addonValidator = new Validator({_: ['foo']});
+    addonValidator.handleError = sinon.stub();
     addonValidator.checkFileExists = () => Promise.resolve();
     addonValidator.scanFile = () => {
       return Promise.reject(new Error('scanFile explosion'));

--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -103,6 +103,7 @@ describe('Validator', function() {
   // - install.rdf
   it('should send JSScanner messages to the collector', () => {
     var addonValidator = new Validator({_: ['tests/example.xpi']});
+    // Stub print to prevent output.
     addonValidator.print = sinon.stub();
 
     assert.equal(addonValidator.collector.errors.length, 0);
@@ -116,6 +117,7 @@ describe('Validator', function() {
   // Test to make sure we can all JS files inside an add-on, not just one.
   it('should scan all JS files', () => {
     var addonValidator = new Validator({_: ['tests/example.xpi']});
+    // Stub print to prevent output.
     addonValidator.print = sinon.stub();
 
     var getFileSpy = sinon.spy(addonValidator, 'scanFile');
@@ -129,6 +131,7 @@ describe('Validator', function() {
   it('should see an error if scanFiles() blows up', () => {
     var addonValidator = new Validator({_: ['foo']});
     addonValidator.checkFileExists = () => Promise.resolve();
+    // Stub handleError to prevent output.
     addonValidator.handleError = sinon.stub();
     addonValidator.scanFiles = () => {
       return Promise.reject(new Error('scanFiles explosion'));
@@ -152,6 +155,7 @@ describe('Validator', function() {
 
   it('should bubble up the error if scanFile() blows up', () => {
     var addonValidator = new Validator({_: ['foo']});
+    // Stub handleError to prevent output.
     addonValidator.handleError = sinon.stub();
     addonValidator.checkFileExists = () => Promise.resolve();
     addonValidator.scanFile = () => {


### PR DESCRIPTION
(See #69)

This just stubs the code paths that otherwise lead to output.