### PR TITLE
Use terminal width for CLI wrapping

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@ import { singleLineString } from 'utils';
 import { version } from 'json!../package';
 
 
-export function _terminalWidth(_process=process) {
+export function terminalWidth(_process=process) {
   if (_process && _process.stdout && _process.stdout.columns > 0) {
     var width = _process.stdout.columns - 2;
     // Terminals less than ten pixels wide seem silly.
@@ -94,4 +94,4 @@ export default argv
   .demand(1)
   .help('help')
   .alias('h', 'help')
-  .wrap(_terminalWidth());
+  .wrap(terminalWidth());

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,6 +4,19 @@ import { singleLineString } from 'utils';
 import { version } from 'json!../package';
 
 
+export function _terminalWidth(_process=process) {
+  if (_process && _process.stdout && _process.stdout.columns > 0) {
+    var width = _process.stdout.columns - 2;
+    // Terminals less than ten pixels wide seem silly.
+    if (width < 10) {
+      width = 10;
+    }
+
+    return width;
+  } else {
+    return 78;
+  }
+}
 
 export default argv
   .usage('Usage: ./$0 [options] addon-package \n\n' +
@@ -81,4 +94,4 @@ export default argv
   .demand(1)
   .help('help')
   .alias('h', 'help')
-  .wrap(78);
+  .wrap(_terminalWidth());

--- a/src/validator.js
+++ b/src/validator.js
@@ -5,6 +5,7 @@ import columnify from 'columnify';
 import chalk from 'chalk';
 import promisify from 'es6-promisify';
 
+import { terminalWidth } from 'cli';
 import * as constants from 'const';
 import * as exceptions from 'exceptions';
 import * as messages from 'messages';
@@ -70,7 +71,8 @@ export default class Validator {
     return _JSON.stringify.apply(null, args);
   }
 
-  textOutput() {
+  textOutput(_terminalWidth=terminalWidth) {
+    var maxColumns = _terminalWidth();
     var out = [];
 
     out.push(_('Validation Summary:'));
@@ -98,34 +100,37 @@ export default class Validator {
               headingTransform: () => {
                 return _('Code');
               },
-              maxWidth: 25,
+              maxWidth: 35,
             },
             message: {
               headingTransform: () => {
                 return _('Message');
               },
-              maxWidth: 30,
+              maxWidth: (maxColumns - 47) * .25,
             },
             description: {
               headingTransform: () => {
                 return _('Description');
               },
-              maxWidth: 40,
+              maxWidth: (maxColumns - 35) * .5,
             },
             file: {
               headingTransform: () => {
                 return _('File');
               },
+              maxWidth: (maxColumns - 35) * .25,
             },
             line: {
               headingTransform: () => {
                 return _('Line');
               },
+              maxWidth: 6,
             },
             column: {
               headingTransform: () => {
                 return _('Column');
               },
+              maxWidth: 6,
             },
           },
         }));

--- a/src/validator.js
+++ b/src/validator.js
@@ -86,53 +86,84 @@ export default class Validator {
     for (let type of constants.MESSAGE_TYPES) {
       var messageType = `${type}s`;
       if (this.output[messageType].length) {
+        var outputConfig = {
+          code: {
+            dataTransform: (value) => {
+              return this.colorize(type)(value);
+            },
+            headingTransform: () => {
+              return _('Code');
+            },
+            maxWidth: 35,
+          },
+          message: {
+            headingTransform: () => {
+              return _('Message');
+            },
+            maxWidth: (maxColumns - 35) * .25,
+          },
+          description: {
+            headingTransform: () => {
+              return _('Description');
+            },
+            maxWidth: (maxColumns - 35) * .5,
+          },
+          file: {
+            headingTransform: () => {
+              return _('File');
+            },
+            maxWidth: (maxColumns - 35) * .25,
+          },
+          line: {
+            headingTransform: () => {
+              return _('Line');
+            },
+            maxWidth: 6,
+          },
+          column: {
+            headingTransform: () => {
+              return _('Column');
+            },
+            maxWidth: 6,
+          },
+        };
+
+        var outputColumns = [
+          'code',
+          'message',
+          'description',
+          'file',
+          'line',
+          'column',
+        ];
+
+        // If the terminal is this small we cave and don't size things
+        // contextually anymore.
+        if (maxColumns < 60) {
+          delete outputColumns[outputColumns.indexOf('column')];
+          delete outputConfig.column;
+          delete outputColumns[outputColumns.indexOf('description')];
+          delete outputConfig.description;
+          delete outputColumns[outputColumns.indexOf('line')];
+          delete outputConfig.line;
+
+          outputConfig.message.maxWidth = 15;
+          outputConfig.file.maxWidth = 15;
+        } else if (maxColumns < 78) {
+          delete outputColumns[outputColumns.indexOf('description')];
+          delete outputConfig.description;
+
+          outputConfig.message.maxWidth = (maxColumns - 47) * .5;
+          outputConfig.file.maxWidth = (maxColumns - 35) * .5;
+        }
+
         out.push(`${messageType.toUpperCase()}:`);
         out.push('');
         out.push(columnify(this.output[messageType], {
           maxWidth: 35,
-          columns: ['code', 'message', 'description', 'file', 'line', 'column'],
+          columns: outputColumns,
           columnSplitter: '   ',
-          config: {
-            code: {
-              dataTransform: (value) => {
-                return this.colorize(type)(value);
-              },
-              headingTransform: () => {
-                return _('Code');
-              },
-              maxWidth: 35,
-            },
-            message: {
-              headingTransform: () => {
-                return _('Message');
-              },
-              maxWidth: (maxColumns - 47) * .25,
-            },
-            description: {
-              headingTransform: () => {
-                return _('Description');
-              },
-              maxWidth: (maxColumns - 35) * .5,
-            },
-            file: {
-              headingTransform: () => {
-                return _('File');
-              },
-              maxWidth: (maxColumns - 35) * .25,
-            },
-            line: {
-              headingTransform: () => {
-                return _('Line');
-              },
-              maxWidth: 6,
-            },
-            column: {
-              headingTransform: () => {
-                return _('Column');
-              },
-              maxWidth: 6,
-            },
-          },
+          config: outputConfig,
         }));
       }
     }

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -1,4 +1,4 @@
-import { default as cli_, _terminalWidth } from 'cli';
+import { default as cli_, terminalWidth } from 'cli';
 
 
 var cli;
@@ -71,32 +71,32 @@ describe('Basic CLI tests', function() {
 
   it('should use 78 as a width if process.stdout.columns is undefined', () => {
     var fakeProcess = null;
-    assert.equal(_terminalWidth(fakeProcess), 78);
+    assert.equal(terminalWidth(fakeProcess), 78);
     fakeProcess = {stdout: null};
-    assert.equal(_terminalWidth(fakeProcess), 78);
+    assert.equal(terminalWidth(fakeProcess), 78);
     fakeProcess = {stdout: {columns: null}};
-    assert.equal(_terminalWidth(fakeProcess), 78);
+    assert.equal(terminalWidth(fakeProcess), 78);
   });
 
   it('should always use a positive terminal width', () => {
     var fakeProcess = {stdout: {columns: 1}};
-    assert.equal(_terminalWidth(fakeProcess), 10);
+    assert.equal(terminalWidth(fakeProcess), 10);
   });
 
   it('should not use a width under 10 columns', () => {
     var fakeProcess = {stdout: {columns: 12}};
-    assert.equal(_terminalWidth(fakeProcess), 10);
+    assert.equal(terminalWidth(fakeProcess), 10);
 
     fakeProcess = {stdout: {columns: 11}};
-    assert.equal(_terminalWidth(fakeProcess), 10);
+    assert.equal(terminalWidth(fakeProcess), 10);
 
     fakeProcess = {stdout: {columns: 79}};
-    assert.equal(_terminalWidth(fakeProcess), 77);
+    assert.equal(terminalWidth(fakeProcess), 77);
   });
 
   it('should use a terminal width of $COLUMNS - 2', () => {
     var fakeProcess = {stdout: {columns: 170}};
-    assert.equal(_terminalWidth(fakeProcess), 168);
+    assert.equal(terminalWidth(fakeProcess), 168);
   });
 
 });

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -1,4 +1,4 @@
-import { default as cli_ } from 'cli';
+import { default as cli_, _terminalWidth } from 'cli';
 
 
 var cli;
@@ -67,6 +67,36 @@ describe('Basic CLI tests', function() {
     assert.ok(
       this.fakeFail.calledWithMatch(
         'Invalid values:\n  Argument: output, Given: "false"'));
+  });
+
+  it('should use 78 as a width if process.stdout.columns is undefined', () => {
+    var fakeProcess = null;
+    assert.equal(_terminalWidth(fakeProcess), 78);
+    fakeProcess = {stdout: null};
+    assert.equal(_terminalWidth(fakeProcess), 78);
+    fakeProcess = {stdout: {columns: null}};
+    assert.equal(_terminalWidth(fakeProcess), 78);
+  });
+
+  it('should always use a positive terminal width', () => {
+    var fakeProcess = {stdout: {columns: 1}};
+    assert.equal(_terminalWidth(fakeProcess), 10);
+  });
+
+  it('should not use a width under 10 columns', () => {
+    var fakeProcess = {stdout: {columns: 12}};
+    assert.equal(_terminalWidth(fakeProcess), 10);
+
+    fakeProcess = {stdout: {columns: 11}};
+    assert.equal(_terminalWidth(fakeProcess), 10);
+
+    fakeProcess = {stdout: {columns: 79}};
+    assert.equal(_terminalWidth(fakeProcess), 77);
+  });
+
+  it('should use a terminal width of $COLUMNS - 2', () => {
+    var fakeProcess = {stdout: {columns: 170}};
+    assert.equal(_terminalWidth(fakeProcess), 168);
   });
 
 });

--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -356,6 +356,12 @@ describe('Validator.toJSON()', function() {
 
 describe('Validator.textOutput()', function() {
 
+  // Return a large number from terminalWidth() so text doesn't wrap,
+  // forcing the strings we check for to be far apart.
+  function terminalWidth() {
+    return 1000;
+  }
+
   it('should have error in textOutput()', () => {
     var addonValidator = new Validator({_: ['bar']});
     addonValidator.collector.addError({
@@ -363,7 +369,7 @@ describe('Validator.textOutput()', function() {
       message: 'whatever error message',
       description: 'whatever error description',
     });
-    var text = addonValidator.textOutput();
+    var text = addonValidator.textOutput(terminalWidth);
     assert.equal(addonValidator.output.summary.errors, 1);
     assert.include(text, 'Validation Summary:');
     assert.include(text, 'WHATEVER_ERROR');
@@ -378,7 +384,7 @@ describe('Validator.textOutput()', function() {
       message: 'whatever notice message',
       description: 'whatever notice description',
     });
-    var text = addonValidator.textOutput();
+    var text = addonValidator.textOutput(terminalWidth);
     assert.equal(addonValidator.output.summary.notices, 1);
     assert.include(text, 'Validation Summary:');
     assert.include(text, 'WHATEVER_NOTICE');
@@ -393,7 +399,7 @@ describe('Validator.textOutput()', function() {
       message: 'whatever warning message',
       description: 'whatever warning description',
     });
-    var text = addonValidator.textOutput();
+    var text = addonValidator.textOutput(terminalWidth);
     assert.equal(addonValidator.output.summary.warnings, 1);
     assert.include(text, 'Validation Summary:');
     assert.include(text, 'WHATEVER_WARNING');


### PR DESCRIPTION
I was using a larger-than-usual terminal window and noticed the output was still wrapped to 78 characters.

This uses process.stdout.columns if available to set the CLI wrap value. (Minus two pixels to preserve a similar padding effect as using 78 over 80).

Kind of a superfluous tweak, but I added a bunch of tests for it and it's nice to be a good CLI citizen like this.

#### Before:
<img width="843" alt="screenshot 2015-10-14 19 59 40" src="https://cloud.githubusercontent.com/assets/90871/10495198/8b871260-72b2-11e5-9aec-2ea6e7e84537.png">

#### After:
<img width="843" alt="screenshot 2015-10-14 20 16 53" src="https://cloud.githubusercontent.com/assets/90871/10495207/96bf9c24-72b2-11e5-8413-7662c8c1d175.png">