### PR TITLE
Use our grunt task for npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mozilla addons validator",
   "main": "index.js",
   "scripts": {
-    "start": "webpack",
+    "start": "node -e \"require('grunt').cli()\" null webpack:build",
     "test": "node -e \"require('grunt').cli()\" null test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mozilla addons validator",
   "main": "index.js",
   "scripts": {
-    "start": "node -e \"require('grunt').cli()\" null webpack:build",
+    "start": "node -e \"require('grunt').cli()\" null webpack",
     "test": "node -e \"require('grunt').cli()\" null test"
   },
   "repository": {


### PR DESCRIPTION
Super-simple tweak; means webpack shouldn't need to be installed globally to run the `npm start` script, which is the node build tool-agnostic command for "get this app to work" to my mind.