### PR TITLE
Add logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ Tests use `grunt` but don't require global `grunt`. Just run:
 ```
 npm test
 ```
+
+## Logging
+
+We use [bunyan](https://github.com/trentm/node-bunyan) for logging:
+
+* By default logging is off (level is set to 'fatal') .
+* Logging in tests can be enabled using an env var e.g: `LOG_LEVEL=debug grunt test`
+* Logging on the cli can be enabled with `--log-level [level]`.
+* Bunyan by default logs JSON. If you want the json to be pretty printed
+  pipe anything that logs into `bunyan` e.g. `LOG_LEVEL=debug grunt test
+  | node_modules/bunyan/bin/bunyan`

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "webpack-dev-server": "1.11.0"
   },
   "dependencies": {
+    "bunyan": "1.5.1",
     "chalk": "1.1.1",
     "cheerio": "0.19.0",
     "columnify": "1.5.2",

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,12 @@ export default argv
       'search', 'multi',
     ],
   })
+  .option('log-level', {
+    describe: 'The log-level to generate',
+    type: 'string',
+    default: 'fatal',
+    choices: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
+  })
   .option('output', {
     alias: 'o',
     describe: 'The type of output to generate',

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,7 @@
+import bunyan from 'bunyan';
+
+export default bunyan.createLogger({
+  name: 'AddonValidatorJS',
+  stream: process.stdout,
+  level: process.env.LOG_LEVEL || 'fatal',
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,11 @@
 import cli from 'cli';
 import Validator from 'validator';
+import log from 'logger';
 
 import 'babel-core/polyfill';
 
-export function createInstance() {
-  return new Validator(cli.argv);
+export function createInstance(config=cli.argv) {
+  log.level(config.logLevel);
+  log.info('Creating new validator instance', { config: config });
+  return new Validator(config);
 }

--- a/src/xpi.js
+++ b/src/xpi.js
@@ -2,6 +2,7 @@ import yauzl from 'yauzl';
 import { singleLineString } from 'utils';
 
 import { DuplicateZipEntryError } from 'exceptions';
+import log from 'logger';
 
 
 /*
@@ -38,6 +39,7 @@ export default class Xpi {
       return;
     }
     if (this.entries.indexOf(entry.fileName) > -1) {
+      log.info('Found duplicate file entry: "%s" in package', entry.fileName);
       reject(new DuplicateZipEntryError(
         `Entry "${entry.fileName}" has already been seen`));
     }

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -18,6 +18,13 @@ describe('Basic CLI tests', function() {
     assert.equal(args.t, 'any');
   });
 
+  it('should default logLevel type to "fatal"', () => {
+    // This means by default there won't be any output.
+    var args = cli.parse(['foo/bar.xpi']);
+    assert.equal(args.logLevel, 'fatal');
+    assert.equal(args['log-level'], 'fatal');
+  });
+
   it('should default add-on output to "text"', () => {
     var args = cli.parse(['foo/bar.xpi']);
     assert.equal(args.output, 'text');


### PR DESCRIPTION
This adds bunyan logging to the validator.

* By default logging is pretty much off (set to 'fatal') .
* Logging in tests can be enabled with `LOG_LEVEL=debug grunt test`
* Logging on the cli can be enabled with `--log-level [level]` as a parameter.
* Bunyan by default logs JSON. If you want the json to be pretty printed pipe anything that logs into `bunyan` e.g. `LOG_LEVEL=debug grunt test | node_modules/bunyan/bin/bunyan`