### PR TITLE
Dry manifest tests

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { Readable } from 'stream';
 
 import { singleLineString } from 'utils';
 
@@ -15,6 +16,24 @@ export function getRuleFiles(ruleType) {
   return ruleFiles.filter((value) => {
     return value !== 'index.js';
   });
+}
+
+export function validChromeManifest(contents=[
+  'category JavaScript-DOM-class foo bar',
+  'category JavaScript-DOM-interface foo bar',
+], {includeBoilerplate=true}={}) {
+  var rstream = new Readable();
+  if (includeBoilerplate === true) {
+    rstream.push('content  necko   jar:comm.jar!/content/necko/\n');
+  }
+
+  contents.forEach((line) => {
+    rstream.push(`${line}\n`);
+  });
+
+  rstream.push(null);
+
+  return rstream;
 }
 
 export function validHTML(contents='') {

--- a/tests/parsers/test.chromemanifest.js
+++ b/tests/parsers/test.chromemanifest.js
@@ -1,24 +1,21 @@
-import { Readable } from 'stream';
-
 import ChromeManifestParser from 'parsers/chromemanifest';
-
+import { validChromeManifest } from '../helpers';
 
 describe('chrome.manifest parser', () => {
 
-  var rstream;
+  var manifest;
 
   beforeEach(() => {
-    rstream = new Readable();
-    rstream.push('content  necko   jar:comm.jar!/content/necko/\n');
-    rstream.push('# I am a comment\n');
-    rstream.push('skin  global  classic/1.0 jar:classic.jar!/skin/classic/\n');
-    rstream.push('locale  necko  en-US  jar:en-US.jar!/locale/en-US/necko/\n');
-    rstream.push('content   pippki   jar:pippki.jar!/content/pippki/\n');
-    rstream.push(null);
+    manifest = validChromeManifest([
+      '# I am a comment',
+      'skin  global  classic/1.0 jar:classic.jar!/skin/classic/',
+      'locale  necko  en-US  jar:en-US.jar!/locale/en-US/necko/',
+      'content   pippki   jar:pippki.jar!/content/pippki/',
+    ]);
   });
 
   it('should parse simple triples', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.parse()
       .then((triples) => {
         assert.equal(triples[0].subject, 'content');
@@ -36,7 +33,7 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should allow for filtering by subject', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.filterTriples({subject: 'content'})
       .then((triples) => {
         assert.equal(triples.length, 2);
@@ -46,7 +43,7 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should allow for filtering by predicate', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.filterTriples({predicate: 'necko'})
       .then((triples) => {
         assert.equal(triples.length, 2);
@@ -56,7 +53,7 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should allow for filtering by predicate', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.filterTriples({object: 'jar:pippki.jar!/content/pippki/'})
       .then((triples) => {
         assert.equal(triples.length, 1);
@@ -65,7 +62,7 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should return cached triples from instance', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     var triples = [{subject: 'foo', predicate: 'bar', object: 'baz'}];
     cmParser.triples = triples;
     return cmParser.parse()
@@ -75,11 +72,10 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should not capture comments', () => {
-    var stream = new Readable();
-    stream.push('# I am a comment\n');
-    stream.push(null);
+    var manifest = validChromeManifest(['# I am a comment'], {
+      includeBoilerplate: false});
 
-    var cmParser = new ChromeManifestParser(stream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.parse()
       .then((triples) => {
         assert.equal(triples.length, 0);
@@ -87,11 +83,10 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should not capture triples without all parts', () => {
-    var stream = new Readable();
-    stream.push('foo\n');
-    stream.push(null);
+    var manifest = validChromeManifest(['foo'], {
+      includeBoilerplate: false});
 
-    var cmParser = new ChromeManifestParser(stream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.parse()
       .then((triples) => {
         assert.equal(triples.length, 0);
@@ -99,7 +94,7 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should have line number', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.parse()
       .then((triples) => {
         assert.equal(triples[0].line, 1);
@@ -109,7 +104,7 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should have filename', () => {
-    var cmParser = new ChromeManifestParser(rstream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.parse()
       .then((triples) => {
         assert.equal(triples[0].filename, 'chrome.manifest');
@@ -117,11 +112,10 @@ describe('chrome.manifest parser', () => {
   });
 
   it('should add object with empty string if only 2 parts to triple', () => {
-    var stream = new Readable();
-    stream.push('foo bar\n');
-    stream.push(null);
+    var manifest = validChromeManifest(['foo bar'], {
+      includeBoilerplate: false});
 
-    var cmParser = new ChromeManifestParser(stream, 'chrome.manifest');
+    var cmParser = new ChromeManifestParser(manifest, 'chrome.manifest');
     return cmParser.parse()
       .then((triples) => {
         assert.equal(triples.length, 1);

--- a/tests/rules/chromemanifest/test.categories.js
+++ b/tests/rules/chromemanifest/test.categories.js
@@ -1,18 +1,17 @@
-import { Readable } from 'stream';
 import { VALIDATION_WARNING } from 'const';
 import { DANGEROUS_CATEGORY } from 'messages';
-
 import ChromeManifestScanner from 'scanners/chromemanifest';
+import { validChromeManifest } from '../../helpers';
 
 
 describe('chrome.manifest Category Rules', () => {
 
   it('should detect dangerous categories', () => {
-    var rstream = new Readable();
-    rstream.push('content  necko   jar:comm.jar!/content/necko/\n');
-    rstream.push('category JavaScript-DOM-class foo bar\n');
-    rstream.push(null);
-    var cmScanner = new ChromeManifestScanner(rstream, 'chrome.manifest');
+    var manifest = validChromeManifest([
+      'category JavaScript-DOM-class foo bar',
+    ]);
+
+    var cmScanner = new ChromeManifestScanner(manifest, 'chrome.manifest');
     return cmScanner.scan()
       .then((messages) => {
         assert.equal(messages.length, 1);
@@ -23,12 +22,12 @@ describe('chrome.manifest Category Rules', () => {
   });
 
   it('should detect multiple dangerous categories', () => {
-    var rstream = new Readable();
-    rstream.push('content  necko   jar:comm.jar!/content/necko/\n');
-    rstream.push('category JavaScript-DOM-class foo bar\n');
-    rstream.push('category JavaScript-DOM-interface foo bar\n');
-    rstream.push(null);
-    var cmScanner = new ChromeManifestScanner(rstream, 'chrome.manifest');
+    var manifest = validChromeManifest([
+      'category JavaScript-DOM-class foo bar',
+      'category JavaScript-DOM-interface foo bar',
+    ]);
+
+    var cmScanner = new ChromeManifestScanner(manifest, 'chrome.manifest');
     return cmScanner.scan()
       .then((messages) => {
         assert.equal(messages.length, 2);

--- a/tests/scanners/test.chromemanifest.js
+++ b/tests/scanners/test.chromemanifest.js
@@ -1,8 +1,6 @@
-import { Readable } from 'stream';
-
 import ChromeManifestScanner from 'scanners/chromemanifest';
 import * as rules from 'rules/chromemanifest';
-import { getRuleFiles } from '../helpers';
+import { getRuleFiles, validChromeManifest } from '../helpers';
 import { ignorePrivateFunctions } from 'utils';
 
 
@@ -14,12 +12,9 @@ describe('ChromeManifestScanner', () => {
       fakeRule2: sinon.stub(),
     };
 
-    var rstream = new Readable();
-    rstream.push('content  necko   jar:comm.jar!/content/necko/\n');
-    rstream.push('category JavaScript-DOM-class foo bar\n');
-    rstream.push('category JavaScript-DOM-interface foo bar\n');
-    rstream.push(null);
-    var cmScanner = new ChromeManifestScanner(rstream, 'chrome.manifest');
+    var manifest = validChromeManifest();
+
+    var cmScanner = new ChromeManifestScanner(manifest, 'chrome.manifest');
     return cmScanner.scan(undefined, fakeRules)
       .then(() => {
         assert.ok(fakeRules.fakeRule1.calledOnce);
@@ -30,12 +25,8 @@ describe('ChromeManifestScanner', () => {
   it('should export and run all rules in rules/chromemanifest', () => {
     var ruleFiles = getRuleFiles('chromemanifest');
 
-    var rstream = new Readable();
-    rstream.push('content  necko   jar:comm.jar!/content/necko/\n');
-    rstream.push('category JavaScript-DOM-class foo bar\n');
-    rstream.push('category JavaScript-DOM-interface foo bar\n');
-    rstream.push(null);
-    var cmScanner = new ChromeManifestScanner(rstream, 'chrome.manifest');
+    var manifest = validChromeManifest();
+    var cmScanner = new ChromeManifestScanner(manifest, 'chrome.manifest');
 
     assert.equal(ruleFiles.length,
                  Object.keys(ignorePrivateFunctions(rules)).length);


### PR DESCRIPTION
Ignore a lot of the commits; this is based on #133.

Just cleans up the ChromeManifest tests a bit; the `rstream.push(null)` bits and the `\n` at the end of every string looked like boilerplate to me so I tidied it up.