### PR TITLE
Pre-process eslint rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,9 +11,20 @@ module.exports = function(grunt) {
 
   grunt.initConfig(configs);
 
+  grunt.registerTask('start', [
+    'webpack:eslintwatch',
+    'webpack:buildwatch',
+  ]);
+
+  grunt.registerTask('build', [
+    'webpack:eslint',
+    'webpack:build',
+  ]);
+
   grunt.registerTask('test', [
     'clean',
     'instrument',
+    'webpack:eslint',
     'webpack:coverage',
     'mochaTest',
     'storeCoverage',
@@ -24,6 +35,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test-no-coverage', [
     'clean',
+    'webpack:eslint',
     'webpack:test',
     'mochaTest',
     'eslint',

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ From the grunt docs:
 |------------------------|--------------------------------------------------|
 | grunt test             |  Runs the tests                                  |
 | grunt test-no-coverage |  Runs the tests (without coverage)               |
-| grunt webpack:build    |  Builds the lib                                  |
-| grunt webpack:watch    |  Builds the lib and watches for changes          |
+| grunt build            |  Builds the lib                                  |
+| grunt start            |  Builds the lib and watches for changes          |
 | grunt eslint           |  Lints the files with eslint (Run in grunt test) |
 | grunt jscs             |  Checks for style issues  (Run in grunt test)    |
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mozilla addons validator",
   "main": "index.js",
   "scripts": {
-    "start": "node -e \"require('grunt').cli()\" null webpack:watch",
+    "start": "node -e \"require('grunt').cli()\" null start",
     "test": "node -e \"require('grunt').cli()\" null test"
   },
   "repository": {

--- a/src/rules/javascript/mozIndexedDB.js
+++ b/src/rules/javascript/mozIndexedDB.js
@@ -1,4 +1,4 @@
-module.exports = function(context) {
+export default function(context) {
   return {
     Identifier: function(node) {
       // Catches `var foo = mozIndexedDB;`.
@@ -8,4 +8,4 @@ module.exports = function(context) {
       }
     },
   };
-};
+}

--- a/src/rules/javascript/mozIndexedDB_property.js
+++ b/src/rules/javascript/mozIndexedDB_property.js
@@ -1,4 +1,4 @@
-module.exports = function(context) {
+export default function(context) {
   return {
     Identifier: function(node) {
       // Catches `var foo = 'mozIndexedDB'; var myDatabase = window[foo];`.
@@ -15,4 +15,4 @@ module.exports = function(context) {
       }
     },
   };
-};
+}

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import ESLint from 'eslint';
 
 import { ESLINT_TYPES } from 'const';
@@ -20,7 +18,7 @@ export default class JavaScriptScanner {
       // pass it the entire source file as a string.
       let eslint = new ESLint.CLIEngine({
         ignore: false,
-        rulePaths: [path.join('src', 'rules', 'javascript')],
+        rulePaths: ['dist/eslint'],
         rules: ESLintRules,
         useEslintrc: false,
       });

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -1,5 +1,6 @@
-var webpackConfig = require('../webpack.config.js');
+var grunt = require('grunt');
 var path = require('path');
+var webpackConfig = require('../webpack.config.js');
 
 var defaultResolve = webpackConfig.resolve;
 
@@ -13,31 +14,64 @@ buildResolve.modulesDirectories.push('src/');
 var coverageResolve = noddyClone(defaultResolve);
 coverageResolve.modulesDirectories.push('coverage/');
 
+// Get the entry-points for the eslint rules using grunt's
+// utils to allow use to use a wildcard.
+// Based on http://stackoverflow.com/a/22715972/156158
+var eslintRulesBasePath = path.resolve('src/rules/javascript');
+var eslintRules = grunt.file.expand({ cwd: eslintRulesBasePath }, '*')
+  .reduce(function(map, page) {
+    map[path.basename(page)] = path.join(eslintRulesBasePath, page);
+    return map;
+  }, {});
+
+var eslintConfig = {
+  entry: eslintRules,
+  output: {
+    path: path.join(__dirname, '../dist/eslint/'),
+    filename: '[name]',
+  },
+};
+
+var testConfig = {
+  entry: './tests/runner.js',
+  output: {
+    path: path.join(__dirname, '../dist'),
+    filename: 'tests.js',
+  },
+};
 
 module.exports = {
   options: webpackConfig,
   build: {
     resolve: buildResolve,
   },
-  watch: {
+  buildwatch: {
     watch: true,
     keepalive: true,
     resolve: buildResolve,
   },
   coverage: {
-    entry: './tests/runner.js',
-    output: {
-      path: path.join(__dirname, '../dist'),
-      filename: 'tests.js',
-    },
+    entry: testConfig.entry,
+    output: testConfig.output,
     resolve: coverageResolve,
   },
   test: {
-    entry: './tests/runner.js',
-    output: {
-      path: path.join(__dirname, '../dist'),
-      filename: 'tests.js',
-    },
+    entry: testConfig.entry,
+    output: testConfig.output,
     resolve: buildResolve,
   },
+  // Webpack conf to pre-process all the eslint rules
+  // without bundling.
+  eslint: {
+    entry: eslintConfig.entry,
+    output: eslintConfig.output,
+    resolve: buildResolve,
+  },
+  eslintwatch: {
+    entry: eslintConfig.entry,
+    output: eslintConfig.output,
+    resolve: buildResolve,
+    watch: true,
+  },
+
 };


### PR DESCRIPTION
Fixes #149

This runs webpack over the eslint rules and puts them in dist/eslint and tells eslint to look for them there.

This allows us to use es6 in the eslint rules and we can now import anything we want which means sharing things between rules is now possible.

I re-jigged the commands so the watching still works and both the rules and/or the main lib should be processed correctly. The readme updates have the details.