### PR TITLE
Provide a VERY clear quickstart for devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ addons-validator --help
 If you'd like to help us develop the addons-validator, that's great! It's
 pretty easy to get started, you just need node.js installed on your machine.
 
+### Quick Start
+
+If you have node.js installed, here's the quick start to getting
+your development dependencies installed and building the binary:
+
+```
+npm install
+npm start
+# Leave running to watch for changes or cancel to stop watching.
+bin/addons-validator my-addon.xpi
+```
+
 ### Required node version
 
 addons-validator requires node.js v0.12.x or greater. Using nvm is probably the


### PR DESCRIPTION
All this info is in the README but it's (appropriately) split up into different sections.

Sometimes, though, I get frustrated not seeing _just_ the commands I want to build/run the program I wanna hack on.

Plus we aren't even on npm yet and when @andymckay checked out the lib to run it it became clear to me we didn't provide up-front installation instructions to run the development version.

I find doing this is how I start on things _I_ hack on: let me just see it working locally at all, then I'll see how to run the tests, etc.