### PR TITLE
Add test for eslint rule keys + files

### DIFF
--- a/tests/rules/javascript/test.eslintRulesObject.js
+++ b/tests/rules/javascript/test.eslintRulesObject.js
@@ -1,0 +1,26 @@
+import path from 'path';
+import { existsSync, readdirSync } from 'fs';
+
+import jsRules from 'rules/javascript';
+import { singleLineString } from 'utils';
+
+
+describe('Eslint rules object', () => {
+  it('should have keys that match the file names', () => {
+    for (let jsRule in jsRules) {
+      var jsFilePath = path.join('src/rules/javascript/', `${jsRule}.js`);
+      assert.ok(existsSync(jsFilePath),
+                `key "${jsRule}" doesn't exist at "${jsFilePath}"`);
+    }
+  });
+
+  it('should have files that match the keys', () => {
+    var files = readdirSync('src/rules/javascript')
+      .filter((fileName) => fileName !== 'index.js');
+    for (let fileName of files) {
+      assert.ok(jsRules.hasOwnProperty(path.parse(fileName).name),
+                singleLineString`fileName "${fileName}" does not have a
+                matching key in the eslint rules object.`);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #159

Detects if key missing to match and file and vice versa.