### PR TITLE
Fix mocha colors for solarized users

### DIFF
--- a/tasks/mochaTest.js
+++ b/tasks/mochaTest.js
@@ -3,6 +3,15 @@ module.exports = {
     require: [
       function() {
         /*eslint-disable */
+        // Monkey-patch mocha colors.
+        // Change 90 to 38 so solarized users can see
+        // stack-traces etc.
+        var colors = require('mocha/lib/reporters/base').colors;
+        colors['error stack'] = 38;
+        colors['pass'] = 38;
+        colors['diff gutter'] = 38;
+        colors['fast'] = 38;
+        colors['light'] = 38;
         assert = require('chai').assert;
         sinon = require('sinon');
         /*eslint-enable */


### PR DESCRIPTION
Before: 

<img alt="before" src="https://cloud.githubusercontent.com/assets/1514/10761332/d18ef8e4-7cb8-11e5-8893-e499b6d3bd1b.png">

After:

<img alt="after" src="https://cloud.githubusercontent.com/assets/1514/10761338/d5e9f6a0-7cb8-11e5-8875-591eb6f661f7.png">

