### PR TITLE
Add references for old rules

### DIFF
--- a/src/messages/chromemanifest.js
+++ b/src/messages/chromemanifest.js
@@ -3,6 +3,11 @@ import { gettext as _, singleLineString } from 'utils';
 
 export const DANGEROUS_CATEGORY = {
   code: 'DANGEROUS_CATEGORY',
+  legacyCode: [
+    'testcases_chromemanifest',
+    'test_resourcemodules',
+    'resource_modules',
+  ],
   message: 'Potentially dangerous category entry',
   description: _(singleLineString`Add-ons defining global properties via
     category entries require careful review by an administrative reviewer.`),

--- a/src/messages/css.js
+++ b/src/messages/css.js
@@ -3,6 +3,11 @@ import { gettext as _, singleLineString } from 'utils';
 
 export const MOZ_BINDING_EXT_REFERENCE = {
   code: 'MOZ_BINDING_EXT_REFERENCE',
+  legacyCode: [
+    'css',
+    '_run_css_tests',
+    '-moz-binding_external',
+  ],
   message: _('Illegal reference to external scripts'),
   description: _(singleLineString`-moz-binding may not reference external
     scripts in CSS. This is considered to be a security issue. The script
@@ -12,6 +17,7 @@ export const MOZ_BINDING_EXT_REFERENCE = {
 export const CSS_SYNTAX_ERROR = {
   code: 'CSS_SYNTAX_ERROR',
   // This will be overriden by the reason passed from the error.
+  legacyCode: null,
   message: _('A CSS syntax error was encountered'),
   description: _(singleLineString`An error was found in the CSS file being
     processed as a result further processing of that file is not possible`),

--- a/src/messages/html.js
+++ b/src/messages/html.js
@@ -4,6 +4,11 @@ import { gettext as _, singleLineString } from 'utils';
 export var _tagRequiresAttribute = (tagName, attribute) => {
   return {
     code: `${tagName}_REQUIRES_${attribute}`.toUpperCase(),
+    legacyCode: [
+      'markup',
+      'starttag',
+      `${tagName}_${attribute}`,
+    ],
     message: _(`<${tagName}> missing "${attribute}"`),
     description: _(singleLineString`The <${tagName}> tag requires the
       ${attribute}, but it's missing.`),

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -3,6 +3,11 @@ import { gettext as _, singleLineString } from 'utils';
 
 export const JS_SYNTAX_ERROR = {
   code: 'JS_SYNTAX_ERROR',
+  legacyCode: [
+    'testcases_scripting',
+    'test_js_file',
+    'syntax_error',
+  ],
   message: _('JavaScript syntax error'),
   description: _(singleLineString`There is a JavaScript syntax error in your
     code; validation cannot continue on this file.`),
@@ -10,12 +15,18 @@ export const JS_SYNTAX_ERROR = {
 
 export const MOZINDEXEDDB = {
   code: 'MOZINDEXEDDB',
+  // Original code appeared to have a non-unique err_id which is no
+  // use for comparsions. ('testcases_regex', 'generic', '_generated')
+  legacyCode: null,
   message: _('mozIndexedDB has been removed; use indexedDB instead'),
   description: _('mozIndexedDB has been removed; use indexedDB instead.'),
 };
 
 export const MOZINDEXEDDB_PROPERTY = {
   code: 'MOZINDEXEDDB_PROPERTY',
+  // Original code appeared to have a non-unique err_id which is no
+  // use for comparsions. ('testcases_regex', 'generic', '_generated')
+  legacyCode: null,
   message: _('mozIndexedDB used as an object key/property'),
   description: _('mozIndexedDB has been removed; use indexedDB instead.'),
 };
@@ -23,6 +34,11 @@ export const MOZINDEXEDDB_PROPERTY = {
 export function _nonLiteralUri(method) {
   return {
     code: `${method}_NONLIT_URI`.toUpperCase(),
+    legacyCode: [
+      'js',
+      'instanceactions',
+      `${method}_nonliteral`,
+    ],
     message: _(`'${method}' called with a non-literal uri`),
     description: _(singleLineString`Calling '${method}' with variable
       parameters can result in potential security vulnerabilities if the
@@ -34,6 +50,11 @@ export function _nonLiteralUri(method) {
 export function _methodPassedRemoteUri(method) {
   return {
     code: `${method}_REMOTE_URI`.toUpperCase(),
+    legacyCode: [
+      'js',
+      'instanceactions',
+      `${method}_remote_uri`,
+    ],
     message: _(`'${method}' called with non-local URI`),
     description: _(singleLineString`Calling '${method}' with a non-local
       URI will result in the dialog being opened with chrome privileges.`),

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -3,6 +3,11 @@ import { gettext as _, singleLineString } from 'utils';
 
 export const DUPLICATE_XPI_ENTRY = {
   code: 'DUPLICATE_XPI_ENTRY',
+  legacyCode: [
+    'testcases_packagelayout',
+    'test_layout_all',
+    'duplicate_entries',
+  ],
   message: _('Package contains duplicate entries'),
   description: _(singleLineString`The package contains multiple entries
     with the same name. This practice has been banned. Try unzipping
@@ -11,6 +16,11 @@ export const DUPLICATE_XPI_ENTRY = {
 
 export const TYPE_NO_INSTALL_RDF = {
   code: 'TYPE_NO_INSTALL_RDF',
+  legacyCode: [
+    'typedetection',
+    'detect_type',
+    'missing_install_rdf',
+  ],
   message: _('install.rdf was not found'),
   description: _(singleLineString`The type should be determined by
     install.rdf if present. As there's no install.rdf, type detection
@@ -19,6 +29,11 @@ export const TYPE_NO_INSTALL_RDF = {
 
 export const TYPE_INVALID = {
   code: 'TYPE_INVALID',
+  legacyCode: [
+    'typedetection',
+    'detect_type',
+    'invalid_em_type',
+  ],
   message: _('Invalid <em:type> value'),
   description: _(singleLineString`The only valid values for <em:type>
     are 2, 4, 8, and 32. Any other values are either invalid or
@@ -28,6 +43,11 @@ export const TYPE_INVALID = {
 
 export const TYPE_MISSING = {
   code: 'TYPE_MISSING',
+  legacyCode: [
+    'typedetection',
+    'detect_type',
+    'no_em:type',
+  ],
   message: _('No <em:type> element found in install.rdf'),
   description: _(singleLineString`It isn't always required, but it is
     the most reliable method for determining add-on type.`),
@@ -36,6 +56,11 @@ export const TYPE_MISSING = {
 
 export const TYPE_NOT_DETERMINED = {
   code: 'TYPE_NOT_DETERMINED',
+  legacyCode: [
+    'main',
+    'test_package',
+    'undeterminable_type',
+  ],
   message: _('Unable to determine add-on type'),
   description: _(singleLineString`The type detection algorithm could not
     determine the type of the add-on.`),

--- a/src/messages/rdf.js
+++ b/src/messages/rdf.js
@@ -4,6 +4,9 @@ import { gettext as _, singleLineString } from 'utils';
 export var _tagNotAllowed = (tagName) => {
   return {
     code: `TAG_NOT_ALLOWED_${tagName.toUpperCase()}`,
+    // Non-unique err_id so setting to null
+    // ('testcases_installrdf', '_test_rdf', 'shouldnt_exist')
+    legacyCode: null,
     message: _(`<${tagName}> tag is not allowed`),
     description: _(singleLineString`Your RDF file contains the <${tagName}> tag,
       which is not allowed in an Add-on.`),
@@ -13,6 +16,9 @@ export var _tagNotAllowed = (tagName) => {
 export var _tagNotAllowedIfTag = (tagName, otherTag) => {
   return {
     code: `TAG_NOT_ALLOWED_${tagName.toUpperCase()}`,
+    // Non-unique err_id so setting to null
+    // ('testcases_installrdf', '_test_rdf', 'shouldnt_exist')
+    legacyCode: null,
     message: _(`<${tagName}> cannot be used with <${otherTag}>`),
     description: _(singleLineString`Your RDF file contains the <${tagName}> tag,
       which cannot be used with a <${otherTag}> tag.`),
@@ -22,6 +28,9 @@ export var _tagNotAllowedIfTag = (tagName, otherTag) => {
 export var _tagObsolete = (tagName) => {
   return {
     code: `TAG_OBSOLETE_${tagName.toUpperCase()}`,
+    // Non-unique err_id so setting to null
+    // ('testcases_installrdf', '_test_rdf', 'shouldnt_exist')
+    legacyCode: null,
     message: _(`<${tagName}> tag is obsolete`),
     description: _(singleLineString`Your RDF file contains the <${tagName}> tag,
       which is obsolete.`),

--- a/tests/test.messages.js
+++ b/tests/test.messages.js
@@ -1,6 +1,8 @@
 import { readFileSync } from 'fs';
 
 import * as messages from 'messages';
+import { singleLineString } from 'utils';
+
 
 describe('Messages', function() {
 
@@ -42,6 +44,21 @@ describe('Messages', function() {
     }
   });
 
+  it('should have a legacyCode property in every message', () => {
+    for (let message in messages) {
+      if (typeof messages[message] === 'object') {
+        var legacyCode = messages[message].legacyCode;
+        if ((legacyCode instanceof Array && legacyCode.length !== 3) ||
+            (!(legacyCode instanceof Array) && legacyCode !== null)) {
+          assert.fail(null, null, singleLineString`A valide legacyCode could
+            not be found for code: "${messages[message].code}". Should be
+            an Array with 3 values based on the amo-validator err_id or null.
+            A null value is an explicit way to say the old err_id tuple is not
+            useful e.g. a matching code doesn't exist or it's not unique.`);
+        }
+      }
+    }
+  });
 });
 
 


### PR DESCRIPTION
Fixes #122 

<img alt="1__bash" src="https://cloud.githubusercontent.com/assets/1514/10767615/d11a1594-7cd4-11e5-8974-d4b18003b1a4.png">

A null value is an explicit way to say the old `err_id` tuple is not useful e.g. a matching code doesn't exist or it's not unique. In which case any comparisons done will need to be based on other things or dealt with manually.