### PR TITLE
Add header links

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var md = require('markdown-it')();
 var emoji = require('markdown-it-emoji');
+var markdownItAnchor = require('markdown-it-anchor');
 
 
 module.exports = function(grunt) {
@@ -18,6 +19,9 @@ module.exports = function(grunt) {
 
   grunt.registerTask('buildrules', 'Build the rules', function() {
     md.use(emoji);
+    md.use(markdownItAnchor, {
+      permalink: true,
+    });
     var markdown = md.render(fs.readFileSync('docs/rules.md',
                                              { encoding: 'utf8' }));
     var template = fs.readFileSync('docs/rules.tmpl',

--- a/docs/rules.tmpl
+++ b/docs/rules.tmpl
@@ -11,6 +11,19 @@
     padding: 20px;
     overflow: auto !important;
   }
+
+  .header-anchor {
+    display: none;
+  }
+
+  h1:hover a,
+  h2:hover a,
+  h3:hover a,
+  h4:hover a,
+  h5:hover a {
+    display: inline;
+    color: #ccc;
+  }
 </style>
 <body class="markdown-body">
   {{MARKDOWN}}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "load-grunt-tasks": "3.3.0",
     "markdown-it": "5.0.0",
     "markdown-it-emoji": "1.1.0",
+    "markdown-it-anchor": "2.3.0",
     "mocha": "2.3.3",
     "sinon": "1.17.1",
     "source-map-support": "0.3.2",


### PR DESCRIPTION
Makes it possible to link to sections of rules - e.g. http://mozilla.github.io/addons-validator/#javascript