### PR TITLE
Update eslint to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "columnify": "1.5.2",
     "css": "2.2.1",
     "es6-promisify": "3.0.0",
-    "eslint": "1.7.2",
+    "eslint": "1.8.0",
     "semver": "5.0.3",
     "xmldom": "0.1.19",
     "yargs": "3.27.0",


### PR DESCRIPTION
Did this to see if we could hold off using babel-eslint, but looks to be still necessary for modules (in our code, not the rules). 