### PR TITLE
Add low-level module rule

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,7 +18,7 @@ To update it edit `docs/rules.md` in the
 | :white_check_mark: | warning | complex_prefs_defaults | | Complex code should not appear in preference defaults files | | [testcases/javascript/actions.py](https://github.com/mozilla/amo-validator/blob/master/validator/testcases/javascript/actions.py#L427) | ('testcases_javascript_actions', '_call_expression', 'complex_prefs_defaults_code')| ONLY_PREFS_IN_DEFAULTS |
 | :x: | warning | called_dangerous_global | | `%s` called in potentially dangerous manner' | | | | |
 | :white_check_mark: | error? | eval | | In order to prevent vulnerabilities, the `setTimeout` 'and `setInterval` functions should be called only with function expressions as their first argument. | | [testcases/javascript/actions.py](https://github.com/mozilla/amo-validator/blob/7a8011aba8bf8c665aef2b51eb26d0697b3e19c3/validator/testcases/javascript/actions.py#L488) | | EVAL_STRING_ARG |
-| :x: | warning | low_level_module (not from src) | | Usage of low-level or non-SDK interface | | | | |
+| :white_check_mark: | warning | low_level_module (not from src) | | Usage of low-level or non-SDK interface | | | null | LOW_LEVEL_MODULE |
 | :white_check_mark: | warning | widget | | Use of deprecated SDK module | | | null | DEPREC_SDK_MOD_WIDGET |
 | :negative_squared_cross_mark: | notice |  \_readonly_top | | window.top is a reserved variable | | | ('testcases_javascript_actions', '_readonly_top' | **Removed** |
 | :x: | warning | global_overwrite | | Global variable overwrite | | | | |

--- a/src/const.js
+++ b/src/const.js
@@ -71,3 +71,12 @@ export const BANNED_IDENTIFIERS = [
   'newThread',
   'processNextEvent',
 ];
+
+export const LOW_LEVEL_MODULES = [
+  // Added from bugs 689340, 731109
+  'chrome', 'window-utils', 'observer-service',
+  // Added from bug 845492
+  'window/utils', 'sdk/window/utils', 'sdk/deprecated/window-utils',
+  'tab/utils', 'sdk/tab/utils',
+  'system/events', 'sdk/system/events',
+];

--- a/src/messages/javascript.js
+++ b/src/messages/javascript.js
@@ -140,3 +140,13 @@ export const ONLY_PREFS_IN_DEFAULTS = {
     'complex_prefs_defaults_code',
   ],
 };
+
+export const LOW_LEVEL_MODULE = {
+  code: 'LOW_LEVEL_MODULE',
+  message: _('Usage of low-level or non-SDK interface'),
+  description: _(`Your add-on uses an interface which bypasses the
+    high-level protections of the add-on SDK. This interface
+    should be avoided, and its use may significantly complicate
+    your review process`),
+  legacyCode: null,
+};

--- a/src/rules/javascript/global_require_arg.js
+++ b/src/rules/javascript/global_require_arg.js
@@ -1,0 +1,25 @@
+import { UNEXPECTED_GLOGAL_ARG } from 'messages';
+import { getVariable } from 'utils';
+
+/*
+ * This rule will detect a global passed to `require()` as the first arg
+ *
+ */
+export default function(context) {
+  return {
+    CallExpression: function(node) {
+      if (node.callee.name === 'require' &&
+          node.arguments &&
+          node.arguments.length) {
+        var firstArg = node.arguments[0];
+        if (firstArg.type === 'Identifier') {
+          var pathVar = getVariable(context, firstArg.name);
+          if (typeof pathVar === 'undefined') {
+            // We infer this is probably a global.
+            return context.report(node, UNEXPECTED_GLOGAL_ARG.code);
+          }
+        }
+      }
+    },
+  };
+}

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -3,6 +3,8 @@ import { ESLINT_ERROR, ESLINT_WARNING } from 'const';
 export default {
   banned_identifiers: ESLINT_WARNING,
   eval_string_arg: ESLINT_ERROR,
+  global_require_arg: ESLINT_WARNING,
+  low_level_module: ESLINT_WARNING,
   mozindexeddb: ESLINT_ERROR,
   mozindexeddb_property: ESLINT_WARNING,
   opendialog_nonlit_uri: ESLINT_WARNING,

--- a/tests/rules/javascript/test.low_level_module.js
+++ b/tests/rules/javascript/test.low_level_module.js
@@ -1,0 +1,51 @@
+import { LOW_LEVEL_MODULES,
+         VALIDATION_WARNING } from 'const';
+import JavaScriptScanner from 'scanners/javascript';
+import * as messages from 'messages';
+
+
+describe('low_level_module', () => {
+
+  for (let module of LOW_LEVEL_MODULES) {
+
+    it(`should catch require of ${module} as literal`, () => {
+      var code = `require("${module}");`;
+      var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code,
+                       messages.LOW_LEVEL_MODULE.code);
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+
+    it(`should catch require of "${module}" as var`, () => {
+      var code = `var modPath = '${module}';
+      var whatever = require(modPath);`;
+      var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code,
+                       messages.LOW_LEVEL_MODULE.code);
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+
+    it(`should catch require() first arg "${module}" being a global`, () => {
+      var code = `modPath = '${module}';
+      require(modPath);`;
+      var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code,
+                       messages.UNEXPECTED_GLOGAL_ARG.code);
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+  }
+});


### PR DESCRIPTION
Fixes #112

* This splits the UNEXPECTED_GLOBAL out into its own rule.
* Covers the basic behaviour of the low_level checks.

@kmaglione - could you clarify the rationale for stripping of 'sdk/' in the old validator here? https://github.com/mozilla/amo-validator/blob/master/validator/testcases/javascript/actions.py#L533 it doesn't appear to tie up with the regex tests that were checking this stuff.  Are there requires that might be `sdk/sdk/[module]` or is everything needed already in that list? 

I've left the sdk prefix stripping out at the moment because it makes things harder to read and grok what's actually being looked for. 