### PR TITLE
Increase mocha test timeout

### DIFF
--- a/tasks/mochaTest.js
+++ b/tasks/mochaTest.js
@@ -1,5 +1,6 @@
 module.exports = {
   options: {
+    timeout: 5000,
     require: [
       function() {
         /*eslint-disable */


### PR DESCRIPTION
The default timeout is 2000ms, which tests like "Base Scanner Class
should run all rules" sometimes exceed, even on my fast MacBook.

If you look at the Travis output you can see that that test is getting dangerously close to 2s, last value was 1886ms and I suppose we want to avoid intermittent failures.