### PR TITLE
Refactor manifest parsing

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -49,9 +49,9 @@ export const PACKAGE_TYPES = {
   PACKAGE_SUBPACKAGE: PACKAGE_SUBPACKAGE,
 };
 
-// Types in install.rdf don't match the types
+// Types from install.rdf don't match the types
 // we use internally. This provides a mapping.
-export const INSTALL_RDF_TYPE_MAP = {
+export const ADDON_TYPE_MAP = {
   2: PACKAGE_EXTENSION,
   4: PACKAGE_THEME,
   8: PACKAGE_LANGPACK,
@@ -80,3 +80,7 @@ export const LOW_LEVEL_MODULES = [
   'tab/utils', 'sdk/tab/utils',
   'system/events', 'sdk/system/events',
 ];
+
+export const INSTALL_RDF = 'install.rdf';
+export const MANIFEST_JSON = 'manifest.json';
+export const CHROME_MANIFEST = 'chrome.manifest';

--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -12,7 +12,5 @@ export class ExtensibleError extends Error {
 }
 
 export class DuplicateZipEntryError extends ExtensibleError {}
-
 export class RDFParseError extends ExtensibleError {}
-
 export class NotImplentedError extends ExtensibleError {}

--- a/src/parsers/installrdf.js
+++ b/src/parsers/installrdf.js
@@ -1,0 +1,54 @@
+import { ADDON_TYPE_MAP, INSTALL_RDF } from 'const';
+import { TYPE_INVALID, TYPE_MISSING } from 'messages';
+import log from 'logger';
+import RDFScanner from 'scanners/rdf';
+
+
+export default class InstallRdfParser {
+
+  constructor(rdfString, collector) {
+    this.rdfString = rdfString;
+    // Provides ability to directly add messages to
+    // the collector.
+    this.collector = collector;
+  }
+
+  parseDoc() {
+    var rdfScanner = new RDFScanner(this.rdfString, INSTALL_RDF);
+    return rdfScanner.getContents();
+  }
+
+  getMetaData() {
+    return this.parseDoc()
+      .then((xmlDoc) => {
+        var addonMetaData = {};
+        // Sync metadata property lookups.
+        addonMetaData.type = this._getAddonType(xmlDoc);
+        return Promise.resolve(addonMetaData);
+      });
+  }
+
+  _getAddonType(xmlDoc) {
+    var addonType = null;
+    var typeNodes = xmlDoc.getElementsByTagName('em:type');
+    if (typeNodes.length > 1) {
+      throw new Error('Multiple <em:type> elements found');
+    }
+    var node = typeNodes[0];
+    if (node && node.firstChild && node.firstChild.nodeValue) {
+      var typeValue = node.firstChild.nodeValue;
+      if (!ADDON_TYPE_MAP.hasOwnProperty(typeValue)) {
+        log.debug('Invalid type value "%s"', typeValue);
+        this.collector.addError(TYPE_INVALID);
+      } else {
+        var addonType = ADDON_TYPE_MAP[typeValue];
+        log.debug('Mapping original <em:type> value "%s" -> "%s"',
+                  typeValue, addonType);
+      }
+    } else {
+      log.warn('<em:type> was not found in install.rdf');
+      this.collector.addNotice(TYPE_MISSING);
+    }
+    return addonType;
+  }
+}

--- a/src/parsers/manifestjson.js
+++ b/src/parsers/manifestjson.js
@@ -1,0 +1,41 @@
+import { ADDON_TYPE_MAP,
+         MANIFEST_JSON,
+         PACKAGE_EXTENSION } from 'const';
+import log from 'logger';
+import { TYPE_INVALID,
+         TYPE_MISSING } from 'messages';
+
+
+export default class ManifestJSONParserr {
+
+  constructor(jsonString, collector) {
+    this.jsonString = jsonString;
+    // Provides ability to directly add messages to
+    // the collector.
+    this.collector = collector;
+  }
+
+  getMetaData() {
+    var parsedJSON = JSON.parse(this.jsonString);
+    var addonMetaData = {};
+    addonMetaData.type = this._getAddonType(parsedJSON);
+    return Promise.resolve(addonMetaData);
+  }
+
+  _getAddonType(parsedJSON) {
+    // TODO: Work out what this should really be.
+    var manifestVersion = parsedJSON.manifest_version;
+    if (typeof manifestVersion === 'undefined') {
+      log.debug(`"manifest_version" was not found in ${MANIFEST_JSON}`);
+      this.collector.addError(TYPE_MISSING);
+      return null;
+    }
+    var addonType = ADDON_TYPE_MAP[manifestVersion];
+    if (addonType !== PACKAGE_EXTENSION) {
+      log.debug('Invalid type value "%s"', addonType);
+      this.collector.addError(TYPE_INVALID);
+      return null;
+    }
+    return addonType;
+  }
+}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -59,6 +59,20 @@ export function validRDF(contents) {
   </RDF>`;
 }
 
+export function validManifestJSON(extra) {
+  return JSON.stringify(Object.assign({}, {
+    name: 'my extension',
+    manifest_version: 2,
+    gecko: {
+      id: '{the-addon-id}',
+      strict_min_version: '40.0.0',
+      strict_max_version: '50.*',
+      update_url: 'https://foo/bar',
+    },
+    version: '0.1',
+  }, extra));
+}
+
 export function unexpectedSuccess() {
   return assert.fail(null, null, 'Unexpected success');
 }

--- a/tests/parsers/test.installrdf.js
+++ b/tests/parsers/test.installrdf.js
@@ -1,0 +1,66 @@
+import InstallRdfParser from 'parsers/installrdf';
+import Validator from 'validator';
+
+import * as messages from 'messages';
+import * as constants from 'const';
+
+import { unexpectedSuccess, validRDF } from '../helpers';
+
+
+describe('InstallRdfParser.getMetaData()', function() {
+
+  it('should reject on multiple em:type nodes', () => {
+    var rdf = validRDF('<em:type>2</em:type><em:type>2</em:type>');
+    var installRdfParser = new InstallRdfParser(rdf);
+    return installRdfParser.getMetaData()
+      .then(unexpectedSuccess)
+      .catch((err) => {
+        assert.equal(err.message, 'Multiple <em:type> elements found');
+      });
+  });
+
+  it('should collect an error on invalid type value', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var rdf = validRDF('<em:type>whatevs</em:type>');
+    var installRdfParser = new InstallRdfParser(rdf, addonValidator.collector);
+    return installRdfParser.getMetaData()
+      .then(() => {
+        var errors = addonValidator.collector.errors;
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0].code, messages.TYPE_INVALID.code);
+      });
+  });
+
+  it('should resolve with mapped type value', () => {
+    var rdf = validRDF('<em:type>2</em:type>');
+    var installRdfParser = new InstallRdfParser(rdf);
+    return installRdfParser.getMetaData()
+      .then((addonMetaData) => {
+        // Type 2 maps to 1 PACKAGE_EXTENSION
+        assert.equal(addonMetaData.type, constants.PACKAGE_EXTENSION);
+      });
+  });
+
+  it('should resolve with mapped type value for experiments', () => {
+    var rdf = validRDF('<em:type>128</em:type>');
+    var installRdfParser = new InstallRdfParser(rdf);
+    return installRdfParser.getMetaData()
+      .then((addonMetaData) => {
+        // Type 128 (experiments) maps to 1 PACKAGE_EXTENSION
+        assert.equal(addonMetaData.type, constants.PACKAGE_EXTENSION);
+      });
+  });
+
+  it('should collect a notice if type is missing', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var installRdfParser = new InstallRdfParser(validRDF(''),
+                                                addonValidator.collector);
+    return installRdfParser.getMetaData()
+      .then(() => {
+        var notices = addonValidator.collector.notices;
+        assert.equal(notices.length, 1);
+        assert.equal(notices[0].code, messages.TYPE_MISSING.code);
+      });
+  });
+
+});

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -1,0 +1,51 @@
+import ManifestJSONParser from 'parsers/manifestjson';
+import Validator from 'validator';
+
+import * as messages from 'messages';
+import { PACKAGE_EXTENSION } from 'const';
+
+import { validManifestJSON } from '../helpers';
+
+
+describe('ManifestJSONParser.getMetaData()', function() {
+
+  it('should collect an error on invalid type value', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var json = validManifestJSON({manifest_version: 'whatever'});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonValidator.collector);
+    return manifestJSONParser.getMetaData()
+      .then((metadata) => {
+        assert.equal(metadata.type, null);
+        var errors = addonValidator.collector.errors;
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0].code, messages.TYPE_INVALID.code);
+      });
+  });
+
+  it('should collect a notice if type is missing', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var json = validManifestJSON({manifest_version: undefined});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonValidator.collector);
+    return manifestJSONParser.getMetaData()
+      .then((metadata) => {
+        assert.equal(metadata.type, null);
+        var errors = addonValidator.collector.errors;
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0].code, messages.TYPE_MISSING.code);
+      });
+  });
+
+  it('should have the right type', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var json = validManifestJSON({manifest_version: 2});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonValidator.collector);
+    return manifestJSONParser.getMetaData()
+      .then((metadata) => {
+        assert.equal(metadata.type, PACKAGE_EXTENSION);
+      });
+  });
+
+});


### PR DESCRIPTION
Fixes #226 
Fixes #191 

I ended up moving the install.rdf parsing bits out to its own class and similar for manifest.json. Fallbacks to type detection based on layout remain in the validator for now.

I've made some assumptions about `manifest_version` for the `manifest.json`. Those will need to be checked later but this was a way to get us off the blocks with parsing of both types of manifest integrated together.