### PR TITLE
Require filenames in scanners (fix #207)

### DIFF
--- a/src/exceptions.js
+++ b/src/exceptions.js
@@ -12,5 +12,6 @@ export class ExtensibleError extends Error {
 }
 
 export class DuplicateZipEntryError extends ExtensibleError {}
-export class RDFParseError extends ExtensibleError {}
+export class MissingFilenameError extends ExtensibleError {}
 export class NotImplentedError extends ExtensibleError {}
+export class RDFParseError extends ExtensibleError {}

--- a/src/scanners/base.js
+++ b/src/scanners/base.js
@@ -1,5 +1,5 @@
 import { NotImplentedError } from 'exceptions';
-import { ignorePrivateFunctions } from 'utils';
+import { ensureFilenameExists, ignorePrivateFunctions } from 'utils';
 
 
 export default class BaseScanner {
@@ -12,6 +12,8 @@ export default class BaseScanner {
     this._parsedContent = null;
     this._rulesProcessed = 0;
     this.options = {};
+
+    ensureFilenameExists(this.filename);
   }
 
   scan(_rules=this._defaultRules) {

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -5,7 +5,7 @@ import ESLint from 'eslint';
 import { ESLINT_TYPES } from 'const';
 import * as messages from 'messages';
 import ESLintRules from 'rules/javascript';
-import { singleLineString } from 'utils';
+import { ensureFilenameExists, singleLineString } from 'utils';
 
 
 export default class JavaScriptScanner {
@@ -13,6 +13,8 @@ export default class JavaScriptScanner {
   constructor(code, filename) {
     this.code = code;
     this.filename = filename;
+
+    ensureFilenameExists(this.filename);
   }
 
   scan(_ESLint=ESLint) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import url from 'url';
 
 import semver from 'semver';
 import { PACKAGE_TYPES, LOCAL_PROTOCOLS } from 'const';
+import { MissingFilenameError } from 'exceptions';
 
 /*
  * Template tag for removing whitespace and new lines
@@ -128,6 +129,17 @@ export function ignorePrivateFunctions(list) {
   }
 
   return filteredList;
+}
+
+
+/*
+ * Check a filename to make sure it's valid; used by scanners so we never
+ * accept new scanners that don't specify which file they're referencing.
+ */
+export function ensureFilenameExists(filename) {
+  if (typeof filename !== 'string' || filename.length < 1) {
+    throw new MissingFilenameError('Filename is required');
+  }
 }
 
 

--- a/tests/scanners/test.base.js
+++ b/tests/scanners/test.base.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 
 import BaseScanner from 'scanners/base';
-import { NotImplentedError } from 'exceptions';
+import { MissingFilenameError, NotImplentedError } from 'exceptions';
 import { ignorePrivateFunctions } from 'utils';
 
 
@@ -14,6 +14,17 @@ class BaseScannerWithContents extends BaseScanner {
 }
 
 describe('Base Scanner Class', function() {
+
+  it('should thrown an error without a filename', () => {
+    assert.throws(() => {
+      var baseScanner = new BaseScanner(''); // eslint-disable-line
+    }, MissingFilenameError, 'Filename is required');
+
+    assert.throws(() => {
+      // An empty filename doesn't count either.
+      var baseScanner = new BaseScanner('', ''); // eslint-disable-line
+    }, MissingFilenameError, 'Filename is required');
+  });
 
   it('should reject when _getContents is not implemented', () => {
     var baseScanner = new BaseScanner('', 'index.html');

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -1,4 +1,5 @@
 import { VALIDATION_ERROR, VALIDATION_WARNING } from 'const';
+import { MissingFilenameError } from 'exceptions';
 import JavaScriptScanner from 'scanners/javascript';
 import * as messages from 'messages';
 import * as rules from 'rules/javascript';
@@ -6,7 +7,13 @@ import { singleLineString } from 'utils';
 import { getRuleFiles, unexpectedSuccess } from '../helpers';
 
 
-describe('JavaScript', function() {
+describe('JavaScript Scanner', function() {
+
+  it('should thrown an error without a filename', () => {
+    assert.throws(() => {
+      var jsScanner = new JavaScriptScanner(''); // eslint-disable-line
+    }, MissingFilenameError, 'Filename is required');
+  });
 
   // TODO: Not sure how to test for this one yet; it's pretty messy.
   it.skip(singleLineString`should warn when mozIndexedDB is assembled into

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -1,3 +1,4 @@
+import { MissingFilenameError } from 'exceptions';
 import * as utils from 'utils';
 import { unexpectedSuccess } from './helpers';
 
@@ -106,6 +107,39 @@ describe('utils.getVariable()', function() {
     var undef = utils.getVariable(context, 'doesNotExist');
     assert.equal(typeof undef, 'undefined');
   });
+});
+
+
+describe('utils.ensureFilenameExists()', function() {
+
+  it('should throw error when filename is not a string', () => {
+    assert.throws(() => {
+      utils.ensureFilenameExists();
+    }, MissingFilenameError, 'Filename is required');
+    assert.throws(() => {
+      utils.ensureFilenameExists(0);
+    }, MissingFilenameError, 'Filename is required');
+    assert.throws(() => {
+      utils.ensureFilenameExists(undefined);
+    }, MissingFilenameError, 'Filename is required');
+    assert.throws(() => {
+      utils.ensureFilenameExists(null);
+    }, MissingFilenameError, 'Filename is required');
+  });
+
+  it('should throw error when filename is empty', () => {
+    assert.throws(() => {
+      utils.ensureFilenameExists('');
+    }, MissingFilenameError, 'Filename is required');
+  });
+
+  it('should accept filenames', () => {
+    assert.doesNotThrow(() => {
+      utils.ensureFilenameExists('foo.js');
+      utils.ensureFilenameExists('0');
+    }, MissingFilenameError);
+  });
+
 });
 
 


### PR DESCRIPTION
Simple fix to make sure we always have filenames in our scanners.