### PR TITLE
Remove () for typeof

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -122,7 +122,7 @@ export function ignorePrivateFunctions(list) {
 
   for (let functionName in list) {
     if (functionName.startsWith('_') === false &&
-        typeof(list[functionName]) === 'function') {
+        typeof list[functionName] === 'function') {
       filteredList[functionName] = list[functionName];
     }
   }

--- a/tests/test.utils.js
+++ b/tests/test.utils.js
@@ -169,7 +169,7 @@ describe('utils.ignorePrivateFunctions()', function() {
 
     var publicFunctions = utils.ignorePrivateFunctions(listOfRuleFunctions);
     for (let functionName in publicFunctions) {
-      assert.equal(typeof(publicFunctions[functionName]), 'function');
+      assert.equal(typeof publicFunctions[functionName], 'function');
     }
   });
 


### PR DESCRIPTION
As mentioned in #231, these aren't needed around `typeof`, so I cleared them out to be consistent.