### PR TITLE
Add metadata CLI option and return metadata as JSON

### DIFF
--- a/bin/addons-validator
+++ b/bin/addons-validator
@@ -3,7 +3,7 @@
 var path = require('path');
 
 var AddonValidator = require('../dist/addons-validator').createInstance();
-AddonValidator.scan();
+AddonValidator.run();
 
 var absoluteAppRoot = path.resolve(__dirname);
 global.relativeAppPath = path.relative(process.cwd(), absoluteAppRoot);

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,11 @@ export default argv
     default: 'text',
     choices: ['json', 'text'],
   })
+  .option('metadata', {
+    describe: 'Output only metadata as JSON',
+    type: 'boolean',
+    default: 'false',
+  })
   .option('pretty', {
     describe: 'Prettify JSON output',
     type: 'boolean',

--- a/tests/test.cli.js
+++ b/tests/test.cli.js
@@ -19,6 +19,11 @@ describe('Basic CLI tests', function() {
     assert.equal(args['log-level'], 'fatal');
   });
 
+  it('should default metadata option to false', () => {
+    var args = cli.parse(['foo/bar.xpi']);
+    assert.equal(args.metadata, false);
+  });
+
   it('should default add-on output to "text"', () => {
     var args = cli.parse(['foo/bar.xpi']);
     assert.equal(args.output, 'text');


### PR DESCRIPTION
Fixes #197

* Add a metadata option
* Move things around so we can sanely just run the metadata extraction.
* Outputs the metadata as JSON.
* Removed an unnecessary Promise wrapper.

<img alt="bash" src="https://cloud.githubusercontent.com/assets/1514/11102066/41d8edee-88b2-11e5-8726-0822fc1c813c.png">

Adding more data tomorrow will make this more useful.