### PR TITLE
Remove some unnecessary Promise wrappers

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -86,11 +86,11 @@ export function gettext(str) {
  * Check the minimum node version is met
  */
 export function checkMinNodeVersion(minVersion, _process=process) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     minVersion = minVersion || '0.12.0';
     if (!semver.gte(_process.version, minVersion)) {
-      reject(new Error(singleLineString`Node version must be ${minVersion} or
-                       greater. You are using ${_process.version}.`));
+      throw new Error(singleLineString`Node version must be ${minVersion} or
+                      greater. You are using ${_process.version}.`);
     } else {
       resolve();
     }

--- a/src/xpi.js
+++ b/src/xpi.js
@@ -134,28 +134,28 @@ export default class Xpi {
   }
 
   getFilesByExt(...extensions) {
-    return new Promise((resolve, reject) => {
 
-      for (let ext of extensions) {
-        if (ext.indexOf('.') !== 0) {
-          throw new Error("File extension must start with '.'");
-        }
+    for (let ext of extensions) {
+      if (ext.indexOf('.') !== 0) {
+        // We use Promise.reject as we're not inside a `then()` or a
+        // Promise constructor callback.
+        // If we throw here it won't be caught.
+        return Promise.reject(new Error("File extension must start with '.'"));
       }
+    }
 
-      return this.getMetaData()
-        .then((metadata) => {
-          let files = [];
+    return this.getMetaData()
+      .then((metadata) => {
+        let files = [];
 
-          for (let filename in metadata) {
-            for (let ext of extensions) {
-              if (filename.endsWith(ext)) {
-                files.push(filename);
-              }
+        for (let filename in metadata) {
+          for (let ext of extensions) {
+            if (filename.endsWith(ext)) {
+              files.push(filename);
             }
           }
-          resolve(files);
-        })
-        .catch(reject);
-    });
+        }
+        return files;
+      });
   }
 }

--- a/tests/scanners/test.base.js
+++ b/tests/scanners/test.base.js
@@ -7,9 +7,7 @@ import { ignorePrivateFunctions } from 'utils';
 
 class BaseScannerWithContents extends BaseScanner {
   _getContents() {
-    return new Promise((resolve) => {
-      resolve({});
-    });
+    return Promise.resolve({});
   }
 }
 

--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -205,11 +205,7 @@ describe('Validator', function() {
           new DuplicateZipEntryError('Darnit the zip has dupes!'));
       }
       getFilesByExt() {
-        return new Promise((resolve, reject) => {
-          return this.getMetaData()
-            .then(resolve)
-            .catch(reject);
-        });
+        return this.getMetaData();
       }
     }
     return addonValidator.scan(FakeXpi)


### PR DESCRIPTION
Fixes #240

I've cleaned up some of the Promisey code to try and get rid of some unnecessary bits.

* I've consolidated on using throw instead of reject as long as we're inside a Promise constructor callback, a `then` or a `catch` (though this means then next `catch` up gets the error).
* We must always return something from `then()` but this can just be a value.
* It's unnecessary to wrap Promisey code in a promise just to use `resolve`/`reject`.
