### PR TITLE
Refactor metadata extraction and expose name

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -267,8 +267,9 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- | -------- |
 | :white_check_mark: | notice | missing_install_rdf | | Add-on missing install.rdf for type detection | | [22](https://github.com/mozilla/amo-validator/blob/master/validator/typedetection.py#L22) | ('typedetection', 'detect_type', 'missing_install_rdf') | TYPE_NO_INSTALL_RDF |
-| :white_check_mark: | error | invalid_em_type | | The only valid values for `<em:type>` are 2, 4, 8, and 32 | | [46](https://github.com/mozilla/amo-validator/blob/master/validator/typedetection.py#L46) | ('typedetection', 'detect_type', 'invalid_em_type') | TYPE_INVALID |
-| :white_check_mark: | notice | no_em:type | | No `<em:type>` element found in install.rdf | | [66](https://github.com/mozilla/amo-validator/blob/master/validator/typedetection.py#L66) | ('typedetection', 'detect_type', 'no_em:type') | TYPE_MISSING |
+| :white_check_mark: | error | invalid_em_type | | The only valid values for `<em:type>` are 2, 4, 8, and 32 | | [46](https://github.com/mozilla/amo-validator/blob/master/validator/typedetection.py#L46) | ('typedetection', 'detect_type', 'invalid_em_type') | RDF_TYPE_INVALID |
+| :white_check_mark: | notice | no_em:type | | No `<em:type>` element found in install.rdf | | [66](https://github.com/mozilla/amo-validator/blob/master/validator/typedetection.py#L66) | ('typedetection', 'detect_type', 'no_em:type') | RDF_TYPE_MISSING |
+| :white_check_mark: | notice | no_em:name | | No `<em:name>` element found in install.rdf | | [66](https://github.com/mozilla/amo-validator/blob/master/validator/typedetection.py#L66) | new rule | RDF_NAME_MISSING |
 | :white_check_mark: | error | undeterminable_type | | Unable to determine add-on type | | [195](https://github.com/mozilla/amo-validator/blob/master/validator/submain.py#L195) | ('main', 'test_package', 'undeterminable_type') | TYPE_NOT_DETERMINED |
 
 
@@ -339,4 +340,5 @@ TODO: A lot of these are generated so this will need expanded with each unique c
 
 | Done? | MsgType | Rule name | Addon type | Description | File Type | Source ref | Old Code | New Code |
 | ----- | ------- | --------- | ---------- | ----------- | --------- | ---------- | -------- |
-| :white_check_mark: | warning | N/A |  | manifest_version in manifest.json is not valid. | | null | MANIFEST_VERSION_INVALID |
+| :white_check_mark: | error | N/A |  | manifest_version in manifest.json is not valid. | | null | MANIFEST_VERSION_INVALID |
+| :white_check_mark: | error | N/A |  | name in manifest.json is not valid. | | null | MANIFEST_NAME_INVALID |

--- a/src/messages/layout.js
+++ b/src/messages/layout.js
@@ -27,8 +27,8 @@ export const TYPE_NO_INSTALL_RDF = {
     will be attempted to be inferred by package layout.`),
 };
 
-export const TYPE_INVALID = {
-  code: 'TYPE_INVALID',
+export const RDF_TYPE_INVALID = {
+  code: 'RDF_TYPE_INVALID',
   legacyCode: [
     'typedetection',
     'detect_type',
@@ -41,8 +41,8 @@ export const TYPE_INVALID = {
   filename: 'install.rdf',
 };
 
-export const TYPE_MISSING = {
-  code: 'TYPE_MISSING',
+export const RDF_TYPE_MISSING = {
+  code: 'RDF_TYPE_MISSING',
   legacyCode: [
     'typedetection',
     'detect_type',
@@ -51,6 +51,14 @@ export const TYPE_MISSING = {
   message: _('No <em:type> element found in install.rdf'),
   description: _(singleLineString`It isn't always required, but it is
     the most reliable method for determining add-on type.`),
+  filename: 'install.rdf',
+};
+
+export const RDF_NAME_MISSING = {
+  code: 'RDF_NAME_MISSING',
+  legacyCode: null,
+  message: _('No <em:name> element found in install.rdf'),
+  description: _('<em:name> is required'),
   filename: 'install.rdf',
 };
 

--- a/src/messages/manifestjson.js
+++ b/src/messages/manifestjson.js
@@ -7,3 +7,10 @@ export const MANIFEST_VERSION_INVALID = {
   description: _('See http://mzl.la/20PenXl (MDN Docs) for more information.'),
 };
 
+export const MANIFEST_NAME_INVALID = {
+  code: 'MANIFEST_NAME_INVALID',
+  legacyCode: null,
+  message: _('"name" in the manifest.json is not a valid value'),
+  description: _('See http://mzl.la/1STmr48 (MDN Docs) for more information.'),
+};
+

--- a/src/parsers/installrdf.js
+++ b/src/parsers/installrdf.js
@@ -1,66 +1,78 @@
-import { ADDON_TYPE_MAP, INSTALL_RDF, RDF_DEFAULT_NAMESPACE } from 'const';
-import { TYPE_INVALID, TYPE_MISSING } from 'messages';
+import { ADDON_TYPE_MAP, RDF_DEFAULT_NAMESPACE } from 'const';
+import { RDF_TYPE_INVALID, RDF_NAME_MISSING,
+         RDF_TYPE_MISSING } from 'messages';
 import log from 'logger';
-import RDFScanner from 'scanners/rdf';
 
 
 export default class InstallRdfParser {
 
-  constructor(rdfString, collector, {namespace=RDF_DEFAULT_NAMESPACE}={}) {
-    this.rdfString = rdfString;
+  constructor(xmlDoc, collector, {namespace=RDF_DEFAULT_NAMESPACE}={}) {
+    this.xmlDoc = xmlDoc;
     // Provides ability to directly add messages to
     // the collector.
     this.collector = collector;
     this.namespace = namespace;
   }
 
-  parseDoc() {
-    var rdfScanner = new RDFScanner(this.rdfString, INSTALL_RDF);
-    return rdfScanner.getContents();
-  }
-
   getMetaData() {
-    return this.parseDoc()
-      .then((xmlDoc) => {
-        return Promise.resolve({
-          guid: this._getGUID(xmlDoc),
-          type: this._getAddonType(xmlDoc),
-        });
-      });
+    return Promise.resolve({
+      guid: this._getGUID(),
+      name: this._getName(),
+      type: this._getAddonType(),
+    });
   }
 
-  _getAddonType(xmlDoc) {
-    var addonType = null;
-    var typeNodes = xmlDoc.getElementsByTagName('em:type');
+  _getNode(tag) {
+    var typeNodes = this.xmlDoc.getElementsByTagName(tag);
     if (typeNodes.length > 1) {
-      throw new Error('Multiple <em:type> elements found');
+      throw new Error(`Multiple <${tag}> elements found`);
     }
-    var node = typeNodes[0];
+    return typeNodes[0];
+  }
+
+  _getAddonType() {
+    var addonType = null;
+    var node = this._getNode('em:type');
     if (node && node.firstChild && node.firstChild.nodeValue) {
       var typeValue = node.firstChild.nodeValue;
       if (!ADDON_TYPE_MAP.hasOwnProperty(typeValue)) {
         log.debug('Invalid type value "%s"', typeValue);
-        this.collector.addError(TYPE_INVALID);
+        this.collector.addError(RDF_TYPE_INVALID);
       } else {
-        var addonType = ADDON_TYPE_MAP[typeValue];
+        addonType = ADDON_TYPE_MAP[typeValue];
         log.debug('Mapping original <em:type> value "%s" -> "%s"',
                   typeValue, addonType);
       }
     } else {
       log.warn('<em:type> was not found in install.rdf');
-      this.collector.addNotice(TYPE_MISSING);
+      this.collector.addNotice(RDF_TYPE_MISSING);
     }
     return addonType;
   }
 
-  _getGUID(xmlDoc) {
-    if (xmlDoc.getElementsByTagNameNS(this.namespace, 'id').length > 0) {
-      var idNode = xmlDoc.getElementsByTagNameNS(this.namespace, 'id').item(0);
+  _getGUID() {
+    // NOTE: We validate this rule in one place: `Validator.getAddonMetaData()`.
+    // This is because both `install.rdf` and `manifest.json` share the same
+    // requirements for guid.
+    var idElms = this.xmlDoc.getElementsByTagNameNS(this.namespace, 'id');
+    if (idElms.length > 0) {
+      var idNode = idElms.item(0);
       if (idNode && idNode.childNodes && idNode.childNodes[0]) {
         return idNode.childNodes[0];
       }
     }
-
     return null;
+  }
+
+  _getName() {
+    var node = this._getNode('em:name');
+    var name = null;
+    if (node && node.firstChild && node.firstChild.nodeValue) {
+      name = node.firstChild.nodeValue;
+    } else {
+      log.warn('<em:name> was not found in install.rdf');
+      this.collector.addNotice(RDF_NAME_MISSING);
+    }
+    return name;
   }
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -206,8 +206,13 @@ export default class Validator {
         } else if (xpiFiles.hasOwnProperty(INSTALL_RDF)) {
           log.info('Retrieving metadata from install.rdf');
           return this.xpi.getFileAsString(INSTALL_RDF)
-            .then((rdf) => {
-              return new InstallRdfParser(rdf, this.collector).getMetaData();
+            .then((rdfString) => {
+              // Gets an xml document object.
+              var rdfScanner = new RDFScanner(rdfString, INSTALL_RDF);
+              return rdfScanner.getContents();
+            })
+            .then((xmlDoc) => {
+              return new InstallRdfParser(xmlDoc, this.collector).getMetaData();
             });
         } else if (xpiFiles.hasOwnProperty(MANIFEST_JSON)) {
           log.info('Retrieving metadata from manifest.json');

--- a/tests/parsers/test.installrdf.js
+++ b/tests/parsers/test.installrdf.js
@@ -1,3 +1,5 @@
+import { INSTALL_RDF } from 'const';
+import RDFScanner from 'scanners/rdf';
 import InstallRdfParser from 'parsers/installrdf';
 import Validator from 'validator';
 
@@ -7,12 +9,16 @@ import * as constants from 'const';
 import { unexpectedSuccess, validRDF } from '../helpers';
 
 
-describe('InstallRdfParser.getMetaData()', function() {
+describe('InstallRdfParser._getAddonType()', function() {
 
   it('should reject on multiple em:type nodes', () => {
     var rdf = validRDF('<em:type>2</em:type><em:type>2</em:type>');
-    var installRdfParser = new InstallRdfParser(rdf);
-    return installRdfParser.getMetaData()
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc);
+        return installRdfParser._getAddonType();
+      })
       .then(unexpectedSuccess)
       .catch((err) => {
         assert.equal(err.message, 'Multiple <em:type> elements found');
@@ -22,45 +28,127 @@ describe('InstallRdfParser.getMetaData()', function() {
   it('should collect an error on invalid type value', () => {
     var addonValidator = new Validator({_: ['bar']});
     var rdf = validRDF('<em:type>whatevs</em:type>');
-    var installRdfParser = new InstallRdfParser(rdf, addonValidator.collector);
-    return installRdfParser.getMetaData()
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc,
+                                                    addonValidator.collector);
+        return installRdfParser._getAddonType();
+      })
       .then(() => {
         var errors = addonValidator.collector.errors;
         assert.equal(errors.length, 1);
-        assert.equal(errors[0].code, messages.TYPE_INVALID.code);
+        assert.equal(errors[0].code, messages.RDF_TYPE_INVALID.code);
       });
   });
 
   it('should resolve with mapped type value', () => {
     var rdf = validRDF('<em:type>2</em:type>');
-    var installRdfParser = new InstallRdfParser(rdf);
-    return installRdfParser.getMetaData()
-      .then((addonMetaData) => {
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc);
+        return installRdfParser._getAddonType();
+      })
+      .then((type) => {
         // Type 2 maps to 1 PACKAGE_EXTENSION
-        assert.equal(addonMetaData.type, constants.PACKAGE_EXTENSION);
+        assert.equal(type, constants.PACKAGE_EXTENSION);
       });
   });
 
   it('should resolve with mapped type value for experiments', () => {
     var rdf = validRDF('<em:type>128</em:type>');
-    var installRdfParser = new InstallRdfParser(rdf);
-    return installRdfParser.getMetaData()
-      .then((addonMetaData) => {
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc);
+        return installRdfParser._getAddonType();
+      })
+      .then((type) => {
         // Type 128 (experiments) maps to 1 PACKAGE_EXTENSION
-        assert.equal(addonMetaData.type, constants.PACKAGE_EXTENSION);
+        assert.equal(type, constants.PACKAGE_EXTENSION);
       });
   });
 
   it('should collect a notice if type is missing', () => {
     var addonValidator = new Validator({_: ['bar']});
-    var installRdfParser = new InstallRdfParser(validRDF(''),
-                                                addonValidator.collector);
-    return installRdfParser.getMetaData()
+    // Specifying a different tag e.g. not <em:type>.
+    var rdf = validRDF('<em:name>whatevs</em:name>');
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc,
+                                                    addonValidator.collector);
+        return installRdfParser._getAddonType();
+      })
       .then(() => {
         var notices = addonValidator.collector.notices;
         assert.equal(notices.length, 1);
-        assert.equal(notices[0].code, messages.TYPE_MISSING.code);
+        assert.equal(notices[0].code, messages.RDF_TYPE_MISSING.code);
+      });
+  });
+});
+
+
+describe('InstallRdfParser._getName()', function() {
+
+  it('should extract a name', () => {
+    var rdf = validRDF('<em:name>my-awesome-ext</em:name>');
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc);
+        return installRdfParser._getName();
+      })
+      .then((name) => {
+        assert.equal(name, 'my-awesome-ext');
       });
   });
 
+  it('should collect a notice if name is missing', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var rdf = validRDF('<em:type>1</em:type>');
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc,
+                                                    addonValidator.collector);
+        return installRdfParser._getName();
+      })
+      .then(() => {
+        var notices = addonValidator.collector.notices;
+        assert.equal(notices.length, 1);
+        assert.equal(notices[0].code, messages.RDF_NAME_MISSING.code);
+      });
+  });
+});
+
+describe('InstallRdfParser._getGUID()', function() {
+
+  it('should extract a guid', () => {
+    var rdf = validRDF('<em:id>myid</em:id>');
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc);
+        return installRdfParser._getGUID();
+      })
+      .then((guid) => {
+        assert.equal(guid, 'myid');
+      });
+  });
+
+  it('should return null for guid if not defined', () => {
+    var rdf = validRDF('<em:type>1</em:type>');
+    var rdfScanner = new RDFScanner(rdf, INSTALL_RDF);
+    return rdfScanner.getContents()
+      .then((xmlDoc) => {
+        var installRdfParser = new InstallRdfParser(xmlDoc);
+        return installRdfParser._getGUID();
+      })
+      .then((guid) => {
+        assert.equal(guid, null);
+      });
+
+  });
 });

--- a/tests/parsers/test.manifestjson.js
+++ b/tests/parsers/test.manifestjson.js
@@ -7,20 +7,18 @@ import { PACKAGE_EXTENSION, VALID_MANIFEST_VERSION } from 'const';
 import { validManifestJSON } from '../helpers';
 
 
-describe('ManifestJSONParser.getMetaData()', function() {
+describe('ManifestJSONParser._getManifestVersion()', function() {
 
   it('should collect an error on invalid manifest_version value', () => {
     var addonValidator = new Validator({_: ['bar']});
     var json = validManifestJSON({manifest_version: 'whatever'});
     var manifestJSONParser = new ManifestJSONParser(json,
                                                     addonValidator.collector);
-    return manifestJSONParser.getMetaData()
-      .then((metadata) => {
-        assert.equal(metadata.manifestVersion, null);
-        var errors = addonValidator.collector.errors;
-        assert.equal(errors.length, 1);
-        assert.equal(errors[0].code, messages.MANIFEST_VERSION_INVALID.code);
-      });
+    var manifestVersion = manifestJSONParser._getManifestVersion();
+    assert.equal(manifestVersion, null);
+    var errors = addonValidator.collector.errors;
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, messages.MANIFEST_VERSION_INVALID.code);
   });
 
   it('should have the right manifestVersion', () => {
@@ -28,22 +26,66 @@ describe('ManifestJSONParser.getMetaData()', function() {
     var json = validManifestJSON();
     var manifestJSONParser = new ManifestJSONParser(json,
                                                     addonValidator.collector);
-    return manifestJSONParser.getMetaData()
-      .then((metadata) => {
-        assert.equal(metadata.manifestVersion, VALID_MANIFEST_VERSION);
-      });
+    var manifestVersion = manifestJSONParser._getManifestVersion();
+    assert.equal(manifestVersion, VALID_MANIFEST_VERSION);
   });
+
+});
+
+
+describe('ManifestJSONParser._getType()', function() {
 
   it('should have the right type', () => {
     // Type is always returned as PACKAGE_EXTENSION presently.
-    var addonValidator = new Validator({_: ['bar']});
     var json = validManifestJSON();
+    var manifestJSONParser = new ManifestJSONParser(json);
+    var type = manifestJSONParser._getType();
+    assert.equal(type, PACKAGE_EXTENSION);
+  });
+
+  it('should not allow the type to be user-specified', () => {
+    var json = validManifestJSON({type: 'whatevs'});
+    var manifestJSONParser = new ManifestJSONParser(json);
+    var type = manifestJSONParser._getType();
+    assert.equal(type, PACKAGE_EXTENSION);
+  });
+
+});
+
+
+describe('ManifestJSONParser._getName()', function() {
+
+  it('should extract a name', () => {
+    // Type is always returned as PACKAGE_EXTENSION presently.
+    var json = validManifestJSON({name: 'my-awesome-ext'});
+    var manifestJSONParser = new ManifestJSONParser(json);
+    var name = manifestJSONParser._getName();
+    assert.equal(name, 'my-awesome-ext');
+  });
+
+  it('should collect an error on invalid name value', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var json = validManifestJSON({name: 2});
     var manifestJSONParser = new ManifestJSONParser(json,
                                                     addonValidator.collector);
-    return manifestJSONParser.getMetaData()
-      .then((metadata) => {
-        assert.equal(metadata.type, PACKAGE_EXTENSION);
-      });
+    var name = manifestJSONParser._getName();
+    assert.equal(name, null);
+    var errors = addonValidator.collector.errors;
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, messages.MANIFEST_NAME_INVALID.code);
   });
+
+  it('should collect an error on invalid name value', () => {
+    var addonValidator = new Validator({_: ['bar']});
+    var json = validManifestJSON({name: undefined});
+    var manifestJSONParser = new ManifestJSONParser(json,
+                                                    addonValidator.collector);
+    var name = manifestJSONParser._getName();
+    assert.equal(name, null);
+    var errors = addonValidator.collector.errors;
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].code, messages.MANIFEST_NAME_INVALID.code);
+  });
+
 
 });


### PR DESCRIPTION
Fixes #258 
Fixes #255

* Bit more refactoring to make manifest parsers simpler and easier to test each field in isolation.
* Expose name + validation of it in each case.