### PR TITLE
stub console

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -435,9 +435,9 @@ export default class Validator {
       });
   }
 
-  run(_Xpi=Xpi) {
+  run(_Xpi=Xpi, _console=console) {
     if (this.config.metadata === true) {
-      return this.extractMetaData(_Xpi);
+      return this.extractMetaData(_Xpi, _console);
     } else {
       return this.scan(_Xpi);
     }

--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -681,6 +681,10 @@ describe('Validator.detectTypeFromLayout()', function() {
 
 describe('Validator.run()', function() {
 
+  var fakeConsole = {
+    log: sinon.stub(),
+  };
+
   it('should run extractMetaData()', () => {
     var addonValidator = new Validator({_: ['foo'], metadata: true});
     var fakeMetaData = {type: 1, somethingelse: 'whatever'};
@@ -702,7 +706,7 @@ describe('Validator.run()', function() {
       // stub Xpi class.
     }
 
-    return addonValidator.run(FakeXpi)
+    return addonValidator.run(FakeXpi, fakeConsole)
       .then(() => {
         assert.ok(addonValidator.toJSON.called);
         assert.deepEqual(
@@ -716,7 +720,7 @@ describe('Validator.run()', function() {
     addonValidator.scan = sinon.stub();
     addonValidator.scan.returns(Promise.resolve());
 
-    return addonValidator.run()
+    return addonValidator.run(null, fakeConsole)
       .then(() => {
         assert.ok(addonValidator.scan.called);
       });


### PR DESCRIPTION
Fixes #254 - took a slightly different route as `Validator.print()` isn't a great fit for the metadata output use-case.