### PR TITLE
Initialise addonMetaData as null (close #257)

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -38,7 +38,7 @@ export default class Validator {
     this.chalk = new chalk.constructor(
       {enabled: !this.config.boring});
     this.collector = new Collector();
-    this.addonMetaData = {};
+    this.addonMetaData = null;
   }
 
   colorize(type) {
@@ -193,6 +193,10 @@ export default class Validator {
   }
 
   getAddonMetaData() {
+    if (this.addonMetaData !== null) {
+      return Promise.resolve(this.addonMetaData);
+    }
+
     var _xpiFiles;
 
     return this.xpi.getFiles()
@@ -224,17 +228,19 @@ export default class Validator {
         }
       })
       .then((addonMetaData) => {
-        addonMetaData.architecture = this._getAddonArchitecture(_xpiFiles);
+        this.addonMetaData = addonMetaData;
 
-        if (!addonMetaData.type) {
+        this.addonMetaData.architecture = this._getAddonArchitecture(_xpiFiles);
+
+        if (!this.addonMetaData.type) {
           log.info('Determining addon type failed. Guessing from layout');
           return this.detectTypeFromLayout()
             .then((addonType) => {
-              addonMetaData.type = addonType;
-              return addonMetaData;
+              this.addonMetaData.type = addonType;
+              return this.addonMetaData;
             });
         } else {
-          return addonMetaData;
+          return this.addonMetaData;
         }
       });
   }
@@ -369,7 +375,6 @@ export default class Validator {
         this.xpi = new _Xpi(this.packagePath);
         return this.getAddonMetaData();
       }).then((addonMetaData) => {
-        this.addonMetaData = addonMetaData;
         if (this.config.metadata === true) {
           _console.log(this.toJSON({input: addonMetaData}));
         }

--- a/tests/test.validator.js
+++ b/tests/test.validator.js
@@ -504,6 +504,48 @@ describe('Validator.textOutput()', function() {
 
 describe('Validator.getAddonMetaData()', function() {
 
+  it('should init with null metadata', () => {
+    var addonValidator = new Validator({
+      _: ['tests/fixtures/example.xpi'],
+    });
+
+    addonValidator.print = sinon.stub();
+
+    assert.typeOf(addonValidator.addonMetaData, 'null');
+
+    return addonValidator.scan()
+      .then(() => {
+        return addonValidator.getAddonMetaData();
+      })
+      .then((metadata) => {
+        assert.isAbove(Object.keys(metadata).length, 0);
+      });
+  });
+
+  it('should cache and return cached addonMetaData', () => {
+    var addonValidator = new Validator({
+      _: ['tests/fixtures/example.xpi'],
+    });
+
+    addonValidator.print = sinon.stub();
+
+    // This should only be called once: when the addonMetaData isn't populated.
+    var architectureCall = sinon.spy(addonValidator, '_getAddonArchitecture');
+
+    assert.isFalse(architectureCall.called);
+
+    // `scan()` calls `getAddonMetaData()`, so we consider it called here.
+    return addonValidator.scan()
+      .then(() => {
+        assert.isTrue(architectureCall.calledOnce);
+        assert.typeOf(addonValidator.addonMetaData, 'object');
+        return addonValidator.getAddonMetaData();
+      })
+      .then(() => {
+        assert.isTrue(architectureCall.calledOnce);
+      });
+  });
+
   it('should consider example.xpi a regular add-on', () => {
     var addonValidator = new Validator({
       _: ['tests/fixtures/example.xpi'],


### PR DESCRIPTION
Caches `addonMetaData` object once created and only assigns it in one place.