### PR TITLE
Add options to scanners (fix #311)

### DIFF
--- a/src/scanners/base.js
+++ b/src/scanners/base.js
@@ -4,14 +4,14 @@ import { ensureFilenameExists, ignorePrivateFunctions } from 'utils';
 
 export default class BaseScanner {
 
-  constructor(contents, filename) {
+  constructor(contents, filename, options={}) {
     this.contents = contents;
     this.filename = filename;
+    this.options = options;
     this.validatorMessages = [];
     this._defaultRules = [];
     this._parsedContent = null;
     this._rulesProcessed = 0;
-    this.options = {};
 
     ensureFilenameExists(this.filename);
   }

--- a/src/scanners/css.js
+++ b/src/scanners/css.js
@@ -31,24 +31,22 @@ export default class CSSScanner extends BaseScanner {
     }
 
     var file = cssCode.position.source;
-    var startLine = cssCode.position.start.line;
-    var startColumn = cssCode.position.start.column;
+    var cssOptions = Object.assign({}, this.options, {
+      startLine: cssCode.position.start.line,
+      startColumn: cssCode.position.start.column,
+    });
 
     log.debug('Passing CSS code to rule function "%s"',
       cssInstruction, {
         cssCode: cssCode,
         file: file,
-        startLine: startLine,
-        startColumn: startColumn,
+        startLine: cssOptions.startLine,
+        startColumn: cssOptions.startColumn,
       });
 
     this.validatorMessages = this.validatorMessages.concat(
-      rules[cssInstruction](cssCode, file, {
-        startLine: startLine,
-        startColumn: startColumn,
-      }));
+      rules[cssInstruction](cssCode, file, cssOptions));
   }
-
 
   scan(_rules=this._defaultRules) {
     return new Promise((resolve, reject) => {

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -10,9 +10,10 @@ import { ensureFilenameExists, singleLineString } from 'utils';
 
 export default class JavaScriptScanner {
 
-  constructor(code, filename) {
+  constructor(code, filename, options={}) {
     this.code = code;
     this.filename = filename;
+    this.options = options;
 
     ensureFilenameExists(this.filename);
   }
@@ -34,6 +35,7 @@ export default class JavaScriptScanner {
       });
 
       var validatorMessages = [];
+      // TODO: Consider switching back to `verify()` to get access to settings.
       var report = eslint.executeOnText(this.code, this.filename);
 
       for (let message of report.results[0].messages) {

--- a/src/scanners/rdf.js
+++ b/src/scanners/rdf.js
@@ -10,15 +10,17 @@ export default class RDFScanner extends BaseScanner {
 
   _defaultRules = rules;
 
-  constructor(contents, filename) {
-    super(contents, filename);
+  constructor(contents, filename, options={}) {
+    super(contents, filename, options);
     // I don't think this ever needs to be different, but if it does we can
     // extract the em namespace using:
     //
     //     this.namespace = this._xmlDoc.documentElement._nsMap.em;
     //
     // Inside _getContents.
-    this.options.namespace = RDF_DEFAULT_NAMESPACE;
+    if (typeof this.options.namespace === 'undefined') {
+      this.options.namespace = RDF_DEFAULT_NAMESPACE;
+    }
   }
 
   _getContents() {

--- a/tests/scanners/test.base.js
+++ b/tests/scanners/test.base.js
@@ -24,6 +24,18 @@ describe('Base Scanner Class', function() {
     }, MissingFilenameError, 'Filename is required');
   });
 
+  it('should have an options property', () => {
+    var baseScanner = new BaseScanner('', 'filename.txt');
+    assert.equal(typeof baseScanner.options, 'object');
+    // This test assures us the options can be accessed like an object.
+    assert.equal(typeof baseScanner.options.someUndefinedProp, 'undefined');
+
+    var baseScannerWithOptions = new BaseScanner('', 'filename.txt', {
+      foo: 'bar',
+    });
+    assert.equal(baseScannerWithOptions.options.foo, 'bar');
+  });
+
   it('should reject when _getContents is not implemented', () => {
     var baseScanner = new BaseScanner('', 'index.html');
 

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -15,6 +15,18 @@ describe('JavaScript Scanner', function() {
     }, MissingFilenameError, 'Filename is required');
   });
 
+  it('should have an options property', () => {
+    var jsScanner = new JavaScriptScanner('', 'filename.txt');
+    assert.equal(typeof jsScanner.options, 'object');
+    // This test assures us the options can be accessed like an object.
+    assert.equal(typeof jsScanner.options.someUndefinedProp, 'undefined');
+
+    var jsScannerWithOptions = new JavaScriptScanner('', 'filename.txt', {
+      foo: 'bar',
+    });
+    assert.equal(jsScannerWithOptions.options.foo, 'bar');
+  });
+
   // TODO: Not sure how to test for this one yet; it's pretty messy.
   it.skip(singleLineString`should warn when mozIndexedDB is assembled into
     literal with +=`,

--- a/tests/scanners/test.rdf.js
+++ b/tests/scanners/test.rdf.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import sinon from 'sinon';
 import XMLDom from 'xmldom';
 
+import { RDF_DEFAULT_NAMESPACE } from 'const';
 import { RDFParseError } from 'exceptions';
 import { getRuleFiles, validRDF } from '../helpers';
 import RDFScanner from 'scanners/rdf';
@@ -20,6 +21,17 @@ describe('RDF', function() {
       .then((validatorMessages) => {
         assert.equal(validatorMessages.length, 0);
       });
+  });
+
+  it('should init with the default namespace and accept a new one', () => {
+    var rdfScanner = new RDFScanner('', 'filename.txt');
+    assert.equal(rdfScanner.options.namespace, RDF_DEFAULT_NAMESPACE);
+
+    var namespace = 'https://tofumatt.name/coffee.xml#';
+    var rdfScannerWithNewNS = new RDFScanner('', 'filename.txt', {
+      namespace: namespace,
+    });
+    assert.equal(rdfScannerWithNewNS.options.namespace, namespace);
   });
 
   it('should handle unicode characters', () => {


### PR DESCRIPTION
Started this while doing #190, realised we needed a consistent way to pass in extra data to scanners and this seemed the best way; we can pass all options right onto the rules with this.