### PR TITLE
Import and define rules directly (fix #317)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,12 +31,10 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('start', [
-    'webpack:eslintwatch',
     'webpack:buildwatch',
   ]);
 
   grunt.registerTask('build', [
-    'webpack:eslint',
     'webpack:build',
   ]);
 
@@ -59,7 +57,6 @@ module.exports = function(grunt) {
     'clean',
     'instrument',
     'webpack:build',
-    'webpack:eslint',
     'webpack:coverage',
     'mochaTest',
     'storeCoverage',
@@ -70,7 +67,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test-no-coverage', [
     'clean',
-    'webpack:eslint',
     'webpack:test',
     'mochaTest',
     'eslint',

--- a/src/const.js
+++ b/src/const.js
@@ -4,6 +4,20 @@ export const NO_COMPRESSION = 0;
 export const ESLINT_ERROR = 2;
 export const ESLINT_WARNING = 1;
 
+export const ESLINT_RULE_MAPPING = {
+  banned_identifiers: ESLINT_WARNING,
+  eval_string_arg: ESLINT_ERROR,
+  global_require_arg: ESLINT_WARNING,
+  low_level_module: ESLINT_WARNING,
+  mozindexeddb: ESLINT_ERROR,
+  mozindexeddb_property: ESLINT_WARNING,
+  only_prefs_in_defaults: ESLINT_WARNING,
+  opendialog_nonlit_uri: ESLINT_WARNING,
+  opendialog_remote_uri: ESLINT_WARNING,
+  shallow_wrapper: ESLINT_WARNING,
+  widget_module: ESLINT_WARNING,
+};
+
 export const VALIDATION_ERROR = 'error';
 export const VALIDATION_NOTICE = 'notice';
 export const VALIDATION_WARNING = 'warning';

--- a/src/rules/javascript/banned_identifiers.js
+++ b/src/rules/javascript/banned_identifiers.js
@@ -1,6 +1,6 @@
 import { BANNED_IDENTIFIERS } from 'const';
 
-export default function(context) {
+export function banned_identifiers(context) {
   return {
     Identifier: function(node) {
       if (BANNED_IDENTIFIERS.indexOf(node.name) > -1) {

--- a/src/rules/javascript/eval_string_arg.js
+++ b/src/rules/javascript/eval_string_arg.js
@@ -1,7 +1,7 @@
 import { EVAL_STRING_ARG } from 'messages/javascript';
 import { getVariable } from 'utils';
 
-export default function(context) {
+export function eval_string_arg(context) {
   return {
     CallExpression: function(node) {
       // Check if what's being called is setTimeout or setInterval

--- a/src/rules/javascript/global_require_arg.js
+++ b/src/rules/javascript/global_require_arg.js
@@ -5,7 +5,7 @@ import { getVariable } from 'utils';
  * This rule will detect a global passed to `require()` as the first arg
  *
  */
-export default function(context) {
+export function global_require_arg(context) {
   return {
     CallExpression: function(node) {
       if (node.callee.name === 'require' &&

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -1,15 +1,27 @@
 import { ESLINT_ERROR, ESLINT_WARNING } from 'const';
 
-export default {
+export const ESLintRuleMapping = {
   banned_identifiers: ESLINT_WARNING,
   eval_string_arg: ESLINT_ERROR,
   global_require_arg: ESLINT_WARNING,
   low_level_module: ESLINT_WARNING,
   mozindexeddb: ESLINT_ERROR,
   mozindexeddb_property: ESLINT_WARNING,
+  only_prefs_in_defaults: ESLINT_WARNING,
   opendialog_nonlit_uri: ESLINT_WARNING,
   opendialog_remote_uri: ESLINT_WARNING,
   shallow_wrapper: ESLINT_WARNING,
   widget_module: ESLINT_WARNING,
-  only_prefs_in_defaults: ESLINT_WARNING,
 };
+
+export * from './banned_identifiers';
+export * from './eval_string_arg';
+export * from './global_require_arg';
+export * from './low_level_module';
+export * from './mozindexeddb';
+export * from './mozindexeddb_property';
+export * from './only_prefs_in_defaults';
+export * from './opendialog_nonlit_uri';
+export * from './opendialog_remote_uri';
+export * from './shallow_wrapper';
+export * from './widget_module';

--- a/src/rules/javascript/index.js
+++ b/src/rules/javascript/index.js
@@ -1,19 +1,3 @@
-import { ESLINT_ERROR, ESLINT_WARNING } from 'const';
-
-export const ESLintRuleMapping = {
-  banned_identifiers: ESLINT_WARNING,
-  eval_string_arg: ESLINT_ERROR,
-  global_require_arg: ESLINT_WARNING,
-  low_level_module: ESLINT_WARNING,
-  mozindexeddb: ESLINT_ERROR,
-  mozindexeddb_property: ESLINT_WARNING,
-  only_prefs_in_defaults: ESLINT_WARNING,
-  opendialog_nonlit_uri: ESLINT_WARNING,
-  opendialog_remote_uri: ESLINT_WARNING,
-  shallow_wrapper: ESLINT_WARNING,
-  widget_module: ESLINT_WARNING,
-};
-
 export * from './banned_identifiers';
 export * from './eval_string_arg';
 export * from './global_require_arg';

--- a/src/rules/javascript/low_level_module.js
+++ b/src/rules/javascript/low_level_module.js
@@ -12,7 +12,7 @@ import { getVariable } from 'utils';
  * TODO: Check what the requires_chrome feature does in the old code.
  *
  */
-export default function(context) {
+export function low_level_module(context) {
   return {
     CallExpression: function(node) {
       var requiresLowLevelMod = false;

--- a/src/rules/javascript/mozindexeddb.js
+++ b/src/rules/javascript/mozindexeddb.js
@@ -1,6 +1,6 @@
 import { MOZINDEXEDDB } from 'messages';
 
-export default function(context) {
+export function mozindexeddb(context) {
   return {
     Identifier: function(node) {
       // Catches `var foo = mozIndexedDB;`.

--- a/src/rules/javascript/mozindexeddb_property.js
+++ b/src/rules/javascript/mozindexeddb_property.js
@@ -1,7 +1,7 @@
 import { MOZINDEXEDDB_PROPERTY } from 'messages';
 
 
-export default function(context) {
+export function mozindexeddb_property(context) {
   return {
     Identifier: function(node) {
       // Catches `var foo = 'mozIndexedDB'; var myDatabase = window[foo];`.

--- a/src/rules/javascript/only_prefs_in_defaults.js
+++ b/src/rules/javascript/only_prefs_in_defaults.js
@@ -1,7 +1,7 @@
 import { ONLY_PREFS_IN_DEFAULTS } from 'messages/javascript';
 import { getRootExpression } from 'utils';
 
-export default function(context) {
+export function only_prefs_in_defaults(context) {
   var filename = context.getFilename();
 
   // This rule only applies to files in defaults/preferences

--- a/src/rules/javascript/opendialog_nonlit_uri.js
+++ b/src/rules/javascript/opendialog_nonlit_uri.js
@@ -1,7 +1,7 @@
 import { OPENDIALOG_NONLIT_URI } from 'messages';
 
 
-export default function(context) {
+export function opendialog_nonlit_uri(context) {
   return {
     CallExpression: function(node) {
       if (node.callee.type === 'MemberExpression' &&

--- a/src/rules/javascript/opendialog_remote_uri.js
+++ b/src/rules/javascript/opendialog_remote_uri.js
@@ -2,7 +2,7 @@ import { isLocalUrl } from 'utils';
 import { OPENDIALOG_REMOTE_URI } from 'messages';
 
 
-export default function(context) {
+export function opendialog_remote_uri(context) {
   return {
     CallExpression: function(node) {
       if (node.callee.type === 'MemberExpression' &&

--- a/src/rules/javascript/shallow_wrapper.js
+++ b/src/rules/javascript/shallow_wrapper.js
@@ -6,7 +6,7 @@ import { SHALLOW_WRAPPER } from 'messages';
 // to XRay: https://developer.mozilla.org/en-US/docs/Xray_vision
 //
 // TODO: Find out more about this rule.
-export default function(context) {
+export function shallow_wrapper(context) {
   function _testForShallowWrapper(node) {
     if (node.callee.name === 'XPCNativeWrapper' &&
         node.callee.type === 'Identifier') {

--- a/src/rules/javascript/widget_module.js
+++ b/src/rules/javascript/widget_module.js
@@ -11,7 +11,7 @@ const WIDGET_PATH = 'sdk/widget';
  * TODO: This rule should only be run for jetpack.
  *
  */
-export default function(context) {
+export function widget_module(context) {
   return {
     CallExpression: function(node) {
       var requiresWidgetMod = false;

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -1,11 +1,10 @@
-import path from 'path';
-
 import ESLint from 'eslint';
 
 import { ESLINT_TYPES } from 'const';
 import * as messages from 'messages';
-import ESLintRules from 'rules/javascript';
-import { ensureFilenameExists, singleLineString } from 'utils';
+import * as rules from 'rules/javascript';
+import { ensureFilenameExists, ignorePrivateFunctions,
+         singleLineString } from 'utils';
 
 
 export default class JavaScriptScanner {
@@ -14,31 +13,31 @@ export default class JavaScriptScanner {
     this.code = code;
     this.filename = filename;
     this.options = options;
+    this.validatorMessages = [];
+    this._rulesProcessed = 0;
 
     ensureFilenameExists(this.filename);
   }
 
   scan(_ESLint=ESLint) {
     return new Promise((resolve) => {
-
-      var rulesPath = global.relativeAppPath ?
-        path.join(global.relativeAppPath, '../dist/eslint') : 'dist/eslint';
-
       // ESLint is synchronous and doesn't accept streams, so we need to
       // pass it the entire source file as a string.
-      let eslint = new _ESLint.CLIEngine({
+      var eslint = _ESLint.linter;
+      var ruleFunctions = ignorePrivateFunctions(rules);
+
+      for (let name in ruleFunctions) {
+        this._rulesProcessed++;
+        eslint.defineRule(name, ruleFunctions[name]);
+      }
+
+      var report = eslint.verify(this.code, {
         ignore: false,
-        rulePaths: [rulesPath],
-        rules: ESLintRules,
-        useEslintrc: false,
-        envs: ['es6'],
-      });
+        rules: rules.ESLintRuleMapping,
+        env: { es6: true },
+      }, this.filename);
 
-      var validatorMessages = [];
-      // TODO: Consider switching back to `verify()` to get access to settings.
-      var report = eslint.executeOnText(this.code, this.filename);
-
-      for (let message of report.results[0].messages) {
+      for (let message of report) {
         // Fatal error messages (like SyntaxErrors) are a bit different, we
         // need to handle them specially.
         if (message.fatal === true) {
@@ -54,7 +53,7 @@ export default class JavaScriptScanner {
         var messageObj = messages[message.message];
         var code = message.message;
 
-        validatorMessages.push({
+        this.validatorMessages.push({
           code: code,
           column: message.column,
           description: messageObj.description,
@@ -66,7 +65,7 @@ export default class JavaScriptScanner {
         });
       }
 
-      resolve(validatorMessages);
+      resolve(this.validatorMessages);
     });
   }
 }

--- a/src/scanners/javascript.js
+++ b/src/scanners/javascript.js
@@ -1,6 +1,6 @@
 import ESLint from 'eslint';
 
-import { ESLINT_TYPES } from 'const';
+import { ESLINT_RULE_MAPPING, ESLINT_TYPES } from 'const';
 import * as messages from 'messages';
 import * as rules from 'rules/javascript';
 import { ensureFilenameExists, ignorePrivateFunctions,
@@ -33,7 +33,7 @@ export default class JavaScriptScanner {
 
       var report = eslint.verify(this.code, {
         ignore: false,
-        rules: rules.ESLintRuleMapping,
+        rules: ESLINT_RULE_MAPPING,
         env: { es6: true },
       }, this.filename);
 

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -14,24 +14,6 @@ buildResolve.modulesDirectories.push('src/');
 var coverageResolve = noddyClone(defaultResolve);
 coverageResolve.modulesDirectories.push('coverage/');
 
-// Get the entry-points for the eslint rules using grunt's
-// utils to allow use to use a wildcard.
-// Based on http://stackoverflow.com/a/22715972/156158
-var eslintRulesBasePath = path.resolve('src/rules/javascript');
-var eslintRules = grunt.file.expand({ cwd: eslintRulesBasePath }, '*')
-  .reduce(function(map, page) {
-    map[path.basename(page)] = path.join(eslintRulesBasePath, page);
-    return map;
-  }, {});
-
-var eslintConfig = {
-  entry: eslintRules,
-  output: {
-    path: path.join(__dirname, '../dist/eslint/'),
-    filename: '[name]',
-  },
-};
-
 var testConfig = {
   entry: './tests/runner.js',
   output: {
@@ -60,18 +42,4 @@ module.exports = {
     output: testConfig.output,
     resolve: buildResolve,
   },
-  // Webpack conf to pre-process all the eslint rules
-  // without bundling.
-  eslint: {
-    entry: eslintConfig.entry,
-    output: eslintConfig.output,
-    resolve: buildResolve,
-  },
-  eslintwatch: {
-    entry: eslintConfig.entry,
-    output: eslintConfig.output,
-    resolve: buildResolve,
-    watch: true,
-  },
-
 };

--- a/tests/rules/javascript/test.eslintRulesObject.js
+++ b/tests/rules/javascript/test.eslintRulesObject.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import { existsSync, readdirSync } from 'fs';
 
+import { ESLINT_RULE_MAPPING } from 'const';
 import * as jsRules from 'rules/javascript';
 import { ignorePrivateFunctions, singleLineString } from 'utils';
 
@@ -17,9 +18,8 @@ describe('Eslint rules object', () => {
   it('should have files that match the keys', () => {
     var files = readdirSync('src/rules/javascript')
       .filter((fileName) => fileName !== 'index.js');
-    var ruleMapping = jsRules.ESLintRuleMapping;
     for (let fileName of files) {
-      assert.ok(ruleMapping.hasOwnProperty(path.parse(fileName).name),
+      assert.ok(ESLINT_RULE_MAPPING.hasOwnProperty(path.parse(fileName).name),
                 singleLineString`fileName "${fileName}" does not have a
                 matching key in the eslint rules object.`);
     }

--- a/tests/rules/javascript/test.eslintRulesObject.js
+++ b/tests/rules/javascript/test.eslintRulesObject.js
@@ -1,13 +1,13 @@
 import path from 'path';
 import { existsSync, readdirSync } from 'fs';
 
-import jsRules from 'rules/javascript';
-import { singleLineString } from 'utils';
+import * as jsRules from 'rules/javascript';
+import { ignorePrivateFunctions, singleLineString } from 'utils';
 
 
 describe('Eslint rules object', () => {
   it('should have keys that match the file names', () => {
-    for (let jsRule in jsRules) {
+    for (let jsRule in ignorePrivateFunctions(jsRules)) {
       var jsFilePath = path.join('src/rules/javascript/', `${jsRule}.js`);
       assert.ok(existsSync(jsFilePath),
                 `key "${jsRule}" doesn't exist at "${jsFilePath}"`);
@@ -17,8 +17,9 @@ describe('Eslint rules object', () => {
   it('should have files that match the keys', () => {
     var files = readdirSync('src/rules/javascript')
       .filter((fileName) => fileName !== 'index.js');
+    var ruleMapping = jsRules.ESLintRuleMapping;
     for (let fileName of files) {
-      assert.ok(jsRules.hasOwnProperty(path.parse(fileName).name),
+      assert.ok(ruleMapping.hasOwnProperty(path.parse(fileName).name),
                 singleLineString`fileName "${fileName}" does not have a
                 matching key in the eslint rules object.`);
     }

--- a/tests/rules/javascript/test.mozindexeddb_property.js
+++ b/tests/rules/javascript/test.mozindexeddb_property.js
@@ -34,14 +34,14 @@ describe('mozindexeddb_property', () => {
       });
   });
 
-  it.skip('should warn when mozIndexedDB is used as a literal', () => {
+  it('should warn when mozIndexedDB is used as a literal', () => {
     var code = 'var foo = "mozIndexedDB"; var myDatabase = window[foo];';
     var jsScanner = new JavaScriptScanner(code, 'badcode.js');
 
     return jsScanner.scan()
       .then((validationMessages) => {
         assert.equal(validationMessages.length, 1);
-        assert.equal(validationMessages[0].id,
+        assert.equal(validationMessages[0].code,
                      messages.MOZINDEXEDDB_PROPERTY.code);
         assert.equal(validationMessages[0].type, VALIDATION_WARNING);
       });

--- a/tests/scanners/test.javascript.js
+++ b/tests/scanners/test.javascript.js
@@ -1,4 +1,5 @@
-import { VALIDATION_ERROR, VALIDATION_WARNING } from 'const';
+import { ESLINT_RULE_MAPPING, VALIDATION_ERROR,
+         VALIDATION_WARNING } from 'const';
 import { MissingFilenameError } from 'exceptions';
 import JavaScriptScanner from 'scanners/javascript';
 import * as messages from 'messages';
@@ -155,8 +156,7 @@ describe('JavaScript Scanner', function() {
   it('should export all rules in rules/javascript', () => {
     // We skip the "run" check here for now as that's handled by ESLint.
     var ruleFiles = getRuleFiles('javascript');
-    assert.equal(ruleFiles.length,
-                 Object.keys(rules.ESLintRuleMapping).length);
+    assert.equal(ruleFiles.length, Object.keys(ESLINT_RULE_MAPPING).length);
 
     var jsScanner = new JavaScriptScanner('', 'badcode.js');
 


### PR DESCRIPTION
We can define the ESLint rules directly using the `ESLint.linter.defineRule` API and using `ESLint.linter.verify()` method to scan each file.

This allows our code coverage tools to scan our rules (it caught one skipped test!) and simplifies our build process a lot.