### PR TITLE
Only process a 'rule' type for -moz-binding rule

### DIFF
--- a/src/rules/css/detectBadMozBinding.js
+++ b/src/rules/css/detectBadMozBinding.js
@@ -5,15 +5,18 @@ import { isLocalCSSUri } from 'utils';
 export function detectBadMozBindingURL(cssContent, filename,
                                        {startLine, startColumn}={}) {
   var messageList = [];
-  for (let declaration of cssContent.declarations) {
-    if (declaration.property === '-moz-binding') {
-      if (isLocalCSSUri(declaration.value) === false) {
-        messageList.push(Object.assign({}, messages.MOZ_BINDING_EXT_REFERENCE, {
-          type: 'error',
-          line: startLine,
-          column: startColumn,
-          file: filename,
-        }));
+  if (cssContent.type === 'rule') {
+    for (let declaration of cssContent.declarations) {
+      if (declaration.property === '-moz-binding') {
+        if (isLocalCSSUri(declaration.value) === false) {
+          messageList.push(
+            Object.assign({}, messages.MOZ_BINDING_EXT_REFERENCE, {
+              type: 'error',
+              line: startLine,
+              column: startColumn,
+              file: filename,
+            }));
+        }
       }
     }
   }

--- a/src/scanners/css.js
+++ b/src/scanners/css.js
@@ -13,8 +13,21 @@ export default class CSSScanner extends BaseScanner {
   _defaultRules = rules;
 
   processCode(cssCode, cssInstruction, _rules=this._defaultRules) {
+
+    var file = cssCode.position.source;
+    var cssOptions = Object.assign({}, this.options, {
+      startLine: cssCode.position.start.line,
+      startColumn: cssCode.position.start.column,
+    });
+
+    var info = {
+      file: file,
+      startLine: cssOptions.startLine,
+      startColumn: cssOptions.startColumn,
+    };
+
     if (cssCode.type === 'comment') {
-      log.debug('Found CSS comment. Skipping');
+      log.debug('Found CSS comment. Skipping', info);
       return;
     }
 
@@ -30,19 +43,8 @@ export default class CSSScanner extends BaseScanner {
       return;
     }
 
-    var file = cssCode.position.source;
-    var cssOptions = Object.assign({}, this.options, {
-      startLine: cssCode.position.start.line,
-      startColumn: cssCode.position.start.column,
-    });
-
     log.debug('Passing CSS code to rule function "%s"',
-      cssInstruction, {
-        cssCode: cssCode,
-        file: file,
-        startLine: cssOptions.startLine,
-        startColumn: cssOptions.startColumn,
-      });
+      cssInstruction, info);
 
     this.validatorMessages = this.validatorMessages.concat(
       _rules[cssInstruction](cssCode, file, cssOptions));


### PR DESCRIPTION
Fixes #347 

The problem was we were processing different types like "document" and "keyframes" and these don't have declarations.