### PR TITLE
Covers edge case for deprecated entities

### DIFF
--- a/src/rules/javascript/deprecated_entities.js
+++ b/src/rules/javascript/deprecated_entities.js
@@ -26,17 +26,18 @@ export const DEPRECATED_ENTITIES = [
 export function deprecated_entities(context) {
   return {
     CallExpression: function(node) {
+      let referenceNode = getNodeReference(context, node.callee);
       // We're only looking for calls that look like `foo.bar()`.
-      if (typeof node.callee.object !== 'undefined' &&
-          node.callee.property.type === 'Identifier' &&
-          node.callee.object.type === 'Identifier') {
+      if (typeof referenceNode.object !== 'undefined' &&
+          referenceNode.property.type === 'Identifier' &&
+          referenceNode.object.type === 'Identifier') {
 
-        let nodeReference = getNodeReference(context, node.callee.object);
+        let referenceObject = getNodeReference(context, referenceNode.object);
 
         for (let entity of DEPRECATED_ENTITIES) {
           // Check to see if the node matches a deprecated entity.
-          if (nodeReference.name === entity.object &&
-              node.callee.property.name === entity.property) {
+          if (referenceObject.name === entity.object &&
+              referenceNode.property.name === entity.property) {
             return context.report(node, entity.error.code);
           }
         }

--- a/tests/rules/javascript/test.deprecated_entities.js
+++ b/tests/rules/javascript/test.deprecated_entities.js
@@ -35,6 +35,19 @@ describe('deprecated_entities', () => {
         });
     });
 
+    it(`should still work with variables aliased to ${obj}.${prop}`, () => {
+      var code = `var foo = ${obj}.${prop}; foo();`;
+      var jsScanner = new JavaScriptScanner(code, 'badcode.js');
+
+      return jsScanner.scan()
+        .then((validationMessages) => {
+          assert.equal(validationMessages.length, 1);
+          assert.equal(validationMessages[0].code,
+                       entity.error.code);
+          assert.equal(validationMessages[0].type, VALIDATION_WARNING);
+        });
+    });
+
     it('should not warn about using other member functions', () => {
       var code = `${obj}.doNothing();`;
       var jsScanner = new JavaScriptScanner(code, 'badcode.js');


### PR DESCRIPTION
This commit now covers the edge case for aliasing a variable to inner
properties such as `var foo = document.write; foo()`.