### PR TITLE
Add limit of 100mb for a single file

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -108,3 +108,7 @@ export const MANIFEST_JSON = 'manifest.json';
 export const CHROME_MANIFEST = 'chrome.manifest';
 
 export const VALID_MANIFEST_VERSION = 2;
+
+// The max file size in MB that the
+// io classes will open as strings or streams.
+export const MAX_FILE_SIZE_MB = 100;

--- a/src/io/base.js
+++ b/src/io/base.js
@@ -1,5 +1,6 @@
 import { singleLineString } from '../utils';
 import { NotImplentedError } from 'exceptions';
+import { MAX_FILE_SIZE_MB } from 'const';
 
 /*
  * Base class for io operations for both an Xpi or
@@ -13,8 +14,7 @@ export class IOBase {
     this.entries = [];
     // If this is too large the node process will hit a RangeError
     // when it runs out of memory.
-    let maxMegabytes = 100;
-    this.maxSizeBytes = 1024 * 1024 * maxMegabytes;
+    this.maxSizeBytes = 1024 * 1024 * MAX_FILE_SIZE_MB;
   }
 
   getFile(path, streamOrString='string') {

--- a/src/io/base.js
+++ b/src/io/base.js
@@ -11,6 +11,10 @@ export class IOBase {
     this.path = packageOrDirPath;
     this.files = {};
     this.entries = [];
+    // If this is too large the node process will hit a RangeError
+    // when it runs out of memory.
+    let maxMegabytes = 100;
+    this.maxSizeBytes = 1024 * 1024 * maxMegabytes;
   }
 
   getFile(path, streamOrString='string') {

--- a/src/io/directory.js
+++ b/src/io/directory.js
@@ -36,6 +36,11 @@ export class Directory extends IOBase {
         new Error(`Path "${relativeFilePath}" does not exist in this dir.`));
     }
 
+    if (this.files[relativeFilePath].size > this.maxSizeBytes) {
+      return Promise.reject(
+        new Error(`File "${relativeFilePath}" is too large. Aborting`));
+    }
+
     var absoluteDirPath = path.resolve(this.path);
     var filePath = path.resolve(path.join(absoluteDirPath, relativeFilePath));
 

--- a/src/io/xpi.js
+++ b/src/io/xpi.js
@@ -89,6 +89,10 @@ export class Xpi extends IOBase {
         throw new Error(`Path "${path}" does not exist in this XPI`);
       }
 
+      if (this.files[path].uncompressedSize > this.maxSizeBytes) {
+        throw new Error(`File "${path}" is too large. Aborting.`);
+      }
+
       return this.open()
         .then((zipfile) => {
           zipfile.openReadStream(this.files[path], (err, readStream) => {

--- a/tests/io/test.base.js
+++ b/tests/io/test.base.js
@@ -11,6 +11,7 @@ describe('io.IOBase()', function() {
     assert.equal(io.entries.length, 0);
     assert.equal(Object.keys(io.files).length, 0);
     assert.equal(typeof io.files, 'object');
+    assert.equal(io.maxSizeBytes, 104857600);
   });
 
   it('should should reject calling getFiles()', () => {

--- a/tests/io/test.directory.js
+++ b/tests/io/test.directory.js
@@ -98,6 +98,24 @@ describe('Directory.getFileAsStream()', function() {
 
   });
 
+  it('should reject if file is too big', () => {
+    var myDirectory = new Directory('tests/fixtures/io/');
+    var fakeFileMeta= {
+      size: 1024 * 1024 * 102,
+    };
+    myDirectory.files = {
+      'install.rdf': fakeFileMeta,
+      'chrome.manifest': fakeFileMeta,
+    };
+
+    return myDirectory.getFileAsStream('install.rdf')
+      .then(unexpectedSuccess)
+      .catch((err) => {
+        assert.include(
+          err.message, 'File "install.rdf" is too large');
+      });
+  });
+
   it("should reject if path starts with '/'", () => {
     var myDirectory = new Directory('tests/fixtures/io/');
     myDirectory.files = {
@@ -149,5 +167,24 @@ describe('Directory.getFileAsString()', function() {
         assert.include(err.message, '¡hola!');
       });
   });
+
+  it('should reject if file is too big', () => {
+    var myDirectory = new Directory('tests/fixtures/io/');
+    var fakeFileMeta= {
+      size: 1024 * 1024 * 102,
+    };
+    myDirectory.files = {
+      'install.rdf': fakeFileMeta,
+      'chrome.manifest': fakeFileMeta,
+    };
+
+    return myDirectory.getFileAsString('install.rdf')
+      .then(unexpectedSuccess)
+      .catch((err) => {
+        assert.include(
+          err.message, 'File "install.rdf" is too large');
+      });
+  });
+
 
 });

--- a/tests/io/test.xpi.js
+++ b/tests/io/test.xpi.js
@@ -365,9 +365,47 @@ describe('Xpi.getFileAsStream()', function() {
       });
   });
 
+  it('should reject if file is too big', () => {
+    var myXpi = new Xpi('foo/bar', this.fakeZipLib);
+    var fakeFileMeta= {
+      uncompressedSize: 1024 * 1024 * 102,
+    };
+
+    myXpi.files = {
+      'install.rdf': fakeFileMeta,
+      'chrome.manifest': fakeFileMeta,
+    };
+
+    return myXpi.getFileAsStream('install.rdf')
+      .then(unexpectedSuccess)
+      .catch((err) => {
+        assert.include(
+          err.message, 'File "install.rdf" is too large');
+      });
+  });
+
+  it('should reject if file is too big for getFileAsString too', () => {
+    var myXpi = new Xpi('foo/bar', this.fakeZipLib);
+    var fakeFileMeta = {
+      uncompressedSize: 1024 * 1024 * 102,
+    };
+
+    myXpi.files = {
+      'install.rdf': fakeFileMeta,
+      'chrome.manifest': fakeFileMeta,
+    };
+
+    return myXpi.getFileAsString('install.rdf')
+      .then(unexpectedSuccess)
+      .catch((err) => {
+        assert.include(
+          err.message, 'File "install.rdf" is too large');
+      });
+  });
+
 });
 
-describe('Xpi.getFileAsStream()', function() {
+describe('Xpi.getFilesByExt()', function() {
 
   beforeEach(() => {
     this.fakeZipLib = {


### PR DESCRIPTION
Fixes  #376

You can test this by creating a zip with a file larger than 100mb and it should catch it.

e.g to create a too large install.rdf (with no useful content) you can use:

```
dd if=/dev/zero bs=1024 count=104448 > ../install.rdf
```