### PR TITLE
Add npm package version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/mozilla/addons-validator/badge.svg?branch=master&service=github)](https://coveralls.io/github/mozilla/addons-validator?branch=master)
 [![Dependency Status](https://david-dm.org/mozilla/addons-validator.svg)](https://david-dm.org/mozilla/addons-validator)
 [![devDependency Status](https://david-dm.org/mozilla/addons-validator/dev-status.svg)](https://david-dm.org/mozilla/addons-validator#info=devDependencies)
+[![npm version](https://badge.fury.io/js/addons-validator.svg)](https://badge.fury.io/js/addons-validator)
 
 # addons-validator
 


### PR DESCRIPTION
I tend to lose the link and find myself coming back looking for a badge but there isn't one.